### PR TITLE
Fix defect deletion and enhance marker functionality

### DIFF
--- a/templates/defect_detail.html
+++ b/templates/defect_detail.html
@@ -135,6 +135,39 @@
                                 <option value="Closed" {% if defect.status.lower() == 'closed' %}selected{% endif %}>Closed</option>
                             </select>
                         </div>
+
+                        {# New HTML for marker editing - START #}
+                        <div class="mt-4">
+                            <label for="drawing_id_edit" class="block text-sm font-medium text-gray-700 mb-1">Select Drawing for Marker (Optional)</label>
+                            <select name="drawing_id" id="drawing_id_edit" class="mt-1 block w-full px-3 py-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm">
+                                <option value="">None - Remove existing marker</option>
+                                {% for drawing_item in drawings %} {# 'drawings' is passed from app.py #}
+                                    <option value="{{ drawing_item.id }}" data-file-path="{{ drawing_item.file_path }}" {% if marker and marker.drawing_id == drawing_item.id %}selected{% endif %}>
+                                        {{ drawing_item.name }}
+                                    </option>
+                                {% endfor %}
+                            </select>
+                        </div>
+
+                        <div id="drawingSectionEdit" class="space-y-3 mt-4 {% if not marker or not marker.file_path %}hidden{% endif %}">
+                            <p class="text-sm font-medium text-gray-700">Click on the drawing to place/update the defect location.</p>
+                            <div id="pdfContainerEdit" class="border border-gray-300 w-full h-[300px] sm:h-[400px] md:h-[500px] lg:h-[600px] relative bg-gray-200 flex items-center justify-center rounded-md overflow-hidden">
+                                <div id="pdfStatusEdit" class="text-gray-700 p-4 text-center flex flex-col items-center justify-center">
+                                    {# SVG Spinner an_d Loading text #}
+                                    <svg class="animate-spin h-8 w-8 text-primary mx-auto mb-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                    </svg>
+                                    <span>Loading PDF...</span>
+                                </div>
+                                <canvas id="pdfCanvasEdit" class="absolute top-0 left-0 hidden"></canvas>
+                                <canvas id="markerCanvasEdit" class="absolute top-0 left-0 cursor-crosshair"></canvas>
+                            </div>
+                            <input type="hidden" name="marker_x" id="marker_x_edit" value="{{ marker.x if marker and marker.x is not none else '' }}">
+                            <input type="hidden" name="marker_y" id="marker_y_edit" value="{{ marker.y if marker and marker.y is not none else '' }}">
+                            <input type="hidden" name="page_num" id="page_num_edit" value="{{ marker.page_num if marker and marker.page_num is not none else '1' }}">
+                        </div>
+                        {# New HTML for marker editing - END #}
                         <button type="submit" name="action" value="edit_defect" class="w-full bg-primary hover:bg-primary-hover text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium">Save Changes</button>
                     </form>
                 {% endif %}
@@ -347,4 +380,178 @@
         }
     </script>
     {% endif %}
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    if (typeof pdfjsLib === 'undefined') {
+        console.error("pdfjsLib is not defined. PDF functionality will not work for editing markers.");
+        return;
+    }
+    // Assuming workerSrc is set globally by the other script. If not, uncomment:
+    // pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='js/pdf.worker.min.js') }}";
+
+    const drawingSelectEdit = document.getElementById('drawing_id_edit');
+    const drawingSectionEdit = document.getElementById('drawingSectionEdit');
+    const pdfContainerEdit = document.getElementById('pdfContainerEdit');
+    const pdfStatusEditEl = document.getElementById('pdfStatusEdit');
+    const pdfCanvasEdit = document.getElementById('pdfCanvasEdit');
+    const markerCanvasEdit = document.getElementById('markerCanvasEdit');
+    const markerXInputEdit = document.getElementById('marker_x_edit');
+    const markerYInputEdit = document.getElementById('marker_y_edit');
+    const pageNumInputEdit = document.getElementById('page_num_edit');
+
+    if (!drawingSelectEdit || !drawingSectionEdit || !pdfContainerEdit || !pdfStatusEditEl || !pdfCanvasEdit || !markerCanvasEdit || !markerXInputEdit || !markerYInputEdit || !pageNumInputEdit) {
+        console.warn("Essential marker editing UI elements are missing from defect_detail.html.");
+        return;
+    }
+
+    const ctxEdit = markerCanvasEdit.getContext('2d');
+    let pdfDocEdit = null;
+    let currentPageNumEdit = 1; 
+    let currentScaleEdit = 1;
+    let currentMarkerEdit = null; 
+
+    if (markerXInputEdit.value !== '' && markerYInputEdit.value !== '' && drawingSelectEdit.value) {
+        const selectedOpt = drawingSelectEdit.options[drawingSelectEdit.selectedIndex];
+        if (selectedOpt && selectedOpt.dataset.filePath) {
+             currentMarkerEdit = {
+                x: parseFloat(markerXInputEdit.value),
+                y: parseFloat(markerYInputEdit.value),
+                pageNum: parseInt(pageNumInputEdit.value) || 1,
+                drawing_id: drawingSelectEdit.value 
+            };
+        }
+    }
+
+    function updateStatusEdit(message, isLoading = false) {
+        if (!pdfStatusEditEl) return;
+        if (isLoading) {
+            pdfStatusEditEl.innerHTML = `
+                <svg class="animate-spin h-8 w-8 text-primary mx-auto mb-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+                <span>${message}</span>`;
+            if(pdfCanvasEdit) pdfCanvasEdit.classList.add('hidden');
+        } else {
+            pdfStatusEditEl.textContent = message;
+            if(pdfCanvasEdit) pdfCanvasEdit.classList.toggle('hidden', !!message);
+        }
+        pdfStatusEditEl.style.display = message ? 'flex' : 'none';
+    }
+
+    function drawMarkerEdit() {
+        if (!pdfDocEdit || !ctxEdit || !markerCanvasEdit) return;
+        ctxEdit.clearRect(0, 0, markerCanvasEdit.width, markerCanvasEdit.height);
+        if (currentMarkerEdit && currentMarkerEdit.drawing_id === drawingSelectEdit.value && currentMarkerEdit.pageNum === currentPageNumEdit) {
+            pdfDocEdit.getPage(currentPageNumEdit).then(page => {
+                const viewport = page.getViewport({ scale: currentScaleEdit });
+                const markerRadius = Math.max(5, Math.min(viewport.width, viewport.height) * 0.015);
+                const markerX = currentMarkerEdit.x * viewport.width;
+                const markerY = currentMarkerEdit.y * viewport.height;
+                ctxEdit.beginPath();
+                ctxEdit.arc(markerX, markerY, markerRadius, 0, 2 * Math.PI, false);
+                ctxEdit.fillStyle = 'rgba(255, 0, 0, 0.7)';
+                ctxEdit.fill();
+                ctxEdit.lineWidth = Math.max(1, markerRadius * 0.2);
+                ctxEdit.strokeStyle = 'rgba(0, 0, 0, 0.8)';
+                ctxEdit.stroke();
+            }).catch(e => console.error("Error in drawMarkerEdit getPage:", e));
+        }
+    }
+
+    function renderPageEdit(pageNumber) {
+        if (!pdfDocEdit || !pdfContainerEdit || !pdfCanvasEdit) return;
+        updateStatusEdit(`Rendering page ${pageNumber}...`, true);
+        pdfDocEdit.getPage(pageNumber).then(page => {
+            currentPageNumEdit = pageNumber;
+            pageNumInputEdit.value = currentPageNumEdit;
+            const pageWidth = page.getViewport({ scale: 1 }).width;
+            currentScaleEdit = pdfContainerEdit.clientWidth / pageWidth;
+            const viewport = page.getViewport({ scale: currentScaleEdit });
+            pdfContainerEdit.style.height = `${viewport.height}px`;
+            pdfCanvasEdit.width = viewport.width;
+            pdfCanvasEdit.height = viewport.height;
+            markerCanvasEdit.width = viewport.width;
+            markerCanvasEdit.height = viewport.height;
+            const renderContext = { canvasContext: pdfCanvasEdit.getContext('2d'), viewport: viewport };
+            page.render(renderContext).promise.then(() => {
+                updateStatusEdit('');
+                pdfCanvasEdit.classList.remove('hidden');
+                drawMarkerEdit(); 
+            }).catch(err => {
+                console.error(`Error rendering page ${pageNumber}:`, err);
+                updateStatusEdit('Error rendering PDF page: ' + err.message);
+            });
+        }).catch(err => {
+            console.error(`Error getting page ${pageNumber}:`, err);
+            updateStatusEdit('Error getting PDF page: ' + err.message);
+        });
+    }
+    
+    function loadPdfForEditing() {
+        const selectedOption = drawingSelectEdit.options[drawingSelectEdit.selectedIndex];
+        const filePath = selectedOption.dataset.filePath;
+        const newDrawingId = selectedOption.value; 
+        if (!newDrawingId || (currentMarkerEdit && currentMarkerEdit.drawing_id !== newDrawingId)) {
+            markerXInputEdit.value = '';
+            markerYInputEdit.value = '';
+            pageNumInputEdit.value = (newDrawingId && filePath) ? '1' : ''; 
+            currentMarkerEdit = null; 
+        }
+        if (!filePath) { 
+            drawingSectionEdit.classList.add('hidden');
+            pdfDocEdit = null;
+            if(ctxEdit && markerCanvasEdit) ctxEdit.clearRect(0, 0, markerCanvasEdit.width, markerCanvasEdit.height);
+            return;
+        }
+        drawingSectionEdit.classList.remove('hidden');
+        updateStatusEdit('Loading PDF...', true);
+        const pdfUrl = `/static/${filePath}`;
+        pdfjsLib.getDocument(pdfUrl).promise.then(loadedPdfDoc => {
+            pdfDocEdit = loadedPdfDoc;
+            renderPageEdit(currentMarkerEdit && currentMarkerEdit.drawing_id === newDrawingId ? currentMarkerEdit.pageNum : 1); 
+        }).catch(err => {
+            console.error(`Error loading PDF ${pdfUrl}:`, err);
+            updateStatusEdit('Error loading PDF: ' + err.message);
+            drawingSectionEdit.classList.add('hidden'); 
+        });
+    }
+
+    markerCanvasEdit.addEventListener('click', (event) => {
+        if (!pdfDocEdit || !markerCanvasEdit) return;
+        const rect = markerCanvasEdit.getBoundingClientRect(); 
+        const x = event.clientX - rect.left;
+        const y = event.clientY - rect.top;
+        const normalizedX = x / markerCanvasEdit.clientWidth; 
+        const normalizedY = y / markerCanvasEdit.clientHeight;
+        currentMarkerEdit = { 
+            x: normalizedX, 
+            y: normalizedY, 
+            pageNum: currentPageNumEdit,
+            drawing_id: drawingSelectEdit.value 
+        };
+        markerXInputEdit.value = normalizedX.toFixed(5);
+        markerYInputEdit.value = normalizedY.toFixed(5);
+        pageNumInputEdit.value = currentPageNumEdit;
+        drawMarkerEdit();
+    });
+    
+    drawingSelectEdit.addEventListener('change', loadPdfForEditing);
+    
+    const initialSelectedOption = drawingSelectEdit.options[drawingSelectEdit.selectedIndex];
+    if (drawingSelectEdit.value && initialSelectedOption && initialSelectedOption.dataset.filePath) {
+        loadPdfForEditing();
+    } else {
+        drawingSectionEdit.classList.add('hidden');
+    }
+
+    window.addEventListener('resize', () => {
+         const selectedOptionOnResize = drawingSelectEdit.options[drawingSelectEdit.selectedIndex];
+         if (pdfDocEdit && drawingSelectEdit.value && selectedOptionOnResize && selectedOptionOnResize.dataset.filePath) {
+             renderPageEdit(currentPageNumEdit); 
+         }
+     });
+});
+</script>
 {% endblock %}

--- a/templates/draw.html
+++ b/templates/draw.html
@@ -60,10 +60,20 @@
         let lineWidthScale = 1;
     
         function resizeCanvas() {
+            // Ensure naturalWidth and naturalHeight are available and valid
+            if (!sourceImage.naturalWidth || sourceImage.naturalWidth === 0 || !sourceImage.naturalHeight || sourceImage.naturalHeight === 0) {
+                console.error('Cannot resize canvas: source image dimensions are invalid (e.g., image not loaded or zero size).', 
+                              { w: sourceImage.naturalWidth, h: sourceImage.naturalHeight });
+                // Optionally, display an error message to the user on the canvas or an alert.
+                // For now, just preventing further execution of this function.
+                return;
+            }
+    
             const maxWidth = window.innerWidth - 32; // Account for padding/margins
-            const aspectRatio = sourceImage.width / sourceImage.height;
-            let canvasWidth = sourceImage.width;
-            let canvasHeight = sourceImage.height;
+            // Use naturalWidth and naturalHeight for aspect ratio calculation
+            const aspectRatio = sourceImage.naturalWidth / sourceImage.naturalHeight; 
+            let canvasWidth = sourceImage.naturalWidth;
+            let canvasHeight = sourceImage.naturalHeight;
     
             // Scale canvas to fit viewport width while preserving aspect ratio
             if (canvasWidth > maxWidth) {
@@ -76,14 +86,12 @@
             canvas.style.width = `${canvasWidth}px`;
             canvas.style.height = `${canvasHeight}px`;
     
-            // Calculate line width scale based on canvas width relative to source image
-            lineWidthScale = (canvas.width / window.devicePixelRatio) / sourceImage.width;
-            console.log('Line width scale:', lineWidthScale, 'Canvas width:', canvas.width, 'Source width:', sourceImage.width);
+            // Calculate line width scale based on canvas width relative to source image's natural width
+            lineWidthScale = (canvas.width / window.devicePixelRatio) / sourceImage.naturalWidth;
+            console.log('Line width scale:', lineWidthScale, 'Canvas width:', canvas.width, 'Source naturalWidth:', sourceImage.naturalWidth);
     
-            // Scale context to account for device pixel ratio
             ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
-    
-            redraw();
+            redraw(); // redraw will draw the image
         }
     
         function redraw() {
@@ -245,12 +253,42 @@
     
         // Ensure image is drawn immediately on page load
         function initializeCanvas() {
-            if (sourceImage.complete && sourceImage.naturalWidth !== 0) {
-                // Image is already loaded (e.g., cached)
+            if (sourceImage.complete && sourceImage.naturalWidth !== 0 && sourceImage.naturalHeight !== 0) {
+                console.log('Source image already complete and has dimensions.');
                 resizeCanvas();
+            } else if (sourceImage.naturalWidth === 0 || sourceImage.naturalHeight === 0) {
+                // Image might be 'complete' but still have no dimensions if it failed to load (e.g. 404)
+                console.log('Source image may be complete but has no valid dimensions. Setting up onload...');
+                sourceImage.onload = () => {
+                    console.log('Source image loaded via .onload callback.');
+                    if (sourceImage.naturalWidth === 0 || sourceImage.naturalHeight === 0) {
+                        console.error('Error: Image loaded but naturalWidth or naturalHeight is 0. Cannot display image.');
+                        // Optionally, display an error message to the user on the canvas or an alert.
+                        // For now, logging an error is sufficient.
+                        alert('Error: The image could not be loaded for annotation. Please check the image file and try again.');
+                        return;
+                    }
+                    resizeCanvas();
+                };
+                sourceImage.onerror = () => {
+                    console.error('Error: Image failed to load (onerror event).');
+                    alert('Error: The image failed to load. It might be missing or corrupted.');
+                };
             } else {
-                // Wait for image to load
-                sourceImage.onload = resizeCanvas;
+                 console.log('Source image not yet complete. Setting up onload...');
+                 sourceImage.onload = () => {
+                    console.log('Source image loaded via .onload callback.');
+                     if (sourceImage.naturalWidth === 0 || sourceImage.naturalHeight === 0) {
+                        console.error('Error: Image loaded but naturalWidth or naturalHeight is 0. Cannot display image.');
+                        alert('Error: The image could not be loaded for annotation. Please check the image file and try again.');
+                        return;
+                    }
+                    resizeCanvas();
+                };
+                sourceImage.onerror = () => {
+                    console.error('Error: Image failed to load (onerror event).');
+                    alert('Error: The image failed to load. It might be missing or corrupted.');
+                };
             }
         }
     

--- a/tests/test_defect_marker_management.py
+++ b/tests/test_defect_marker_management.py
@@ -1,0 +1,229 @@
+import unittest
+import os
+from datetime import datetime
+from flask import url_for
+
+# Configure app for testing before importing
+os.environ['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+os.environ['TESTING'] = 'True'
+os.environ['WTF_CSRF_ENABLED'] = 'False'
+os.environ['SECRET_KEY'] = 'test-secret-key-for-sessions'
+os.environ['BCRYPT_LOG_ROUNDS'] = '4' # Speed up hashing for tests
+
+from app import app, db, User, Project, Drawing, Defect, DefectMarker, bcrypt, ProjectAccess
+
+class TestDefectMarkerManagement(unittest.TestCase):
+
+    def setUp(self):
+        self.app = app
+        self.client = self.app.test_client()
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        db.create_all()
+
+        # Create users with different roles
+        admin_user = User(username='test_admin', role='admin', password=bcrypt.generate_password_hash('password').decode('utf-8'))
+        expert_user = User(username='test_expert', role='expert', password=bcrypt.generate_password_hash('password').decode('utf-8'))
+        db.session.add_all([admin_user, expert_user])
+        db.session.commit()
+        self.admin_user_id = admin_user.id
+        self.expert_user_id = expert_user.id
+        
+        # Create a project
+        project = Project(name="Test Project")
+        db.session.add(project)
+        db.session.commit()
+        self.project_id = project.id
+
+        # Grant access to users for the project
+        admin_access = ProjectAccess(user_id=self.admin_user_id, project_id=self.project_id, role='admin')
+        expert_access = ProjectAccess(user_id=self.expert_user_id, project_id=self.project_id, role='expert')
+        db.session.add_all([admin_access, expert_access])
+        db.session.commit()
+
+        # Create a drawing
+        drawing = Drawing(project_id=self.project_id, name="Test Drawing", file_path="drawings/test_drawing.pdf")
+        db.session.add(drawing)
+        db.session.commit()
+        self.drawing_id = drawing.id
+
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def login_user(self, username='test_admin', password='password'):
+        return self.client.post(url_for('login'), data=dict(
+            username=username,
+            password=password
+        ), follow_redirects=True)
+
+    def test_delete_defect_with_marker(self):
+        self.login_user(username='test_admin') # Admin role needed for deletion
+        
+        # Setup: Create defect and marker
+        defect = Defect(project_id=self.project_id, description="Defect to delete", creator_id=self.admin_user_id, creation_date=datetime.now())
+        db.session.add(defect)
+        db.session.commit()
+        defect_id = defect.id
+
+        marker = DefectMarker(defect_id=defect_id, drawing_id=self.drawing_id, x=0.1, y=0.1)
+        db.session.add(marker)
+        db.session.commit()
+        marker_id = marker.id
+
+        self.assertIsNotNone(Defect.query.get(defect_id))
+        self.assertIsNotNone(DefectMarker.query.get(marker_id))
+
+        # Action: Delete defect
+        response = self.client.post(url_for('defect_detail', defect_id=defect_id), data={
+            'action': 'delete_defect'
+        }, follow_redirects=True)
+
+        # Assertions
+        self.assertEqual(response.status_code, 200) # Should redirect to project_detail which is 200
+        self.assertIsNone(Defect.query.get(defect_id))
+        self.assertIsNone(DefectMarker.query.get(marker_id))
+        self.assertIn(b'Defect deleted successfully!', response.data)
+
+
+    def test_add_marker_when_editing_defect(self):
+        self.login_user(username='test_expert') # Expert role can edit
+        
+        defect = Defect(project_id=self.project_id, description="Initial defect", creator_id=self.expert_user_id, creation_date=datetime.now())
+        db.session.add(defect)
+        db.session.commit()
+        defect_id = defect.id
+
+        self.assertEqual(DefectMarker.query.filter_by(defect_id=defect_id).count(), 0)
+
+        # Action: Edit defect and add marker
+        new_description = "Updated defect with marker"
+        response = self.client.post(url_for('defect_detail', defect_id=defect_id), data={
+            'action': 'edit_defect',
+            'description': new_description,
+            'status': 'open',
+            'drawing_id': str(self.drawing_id),
+            'marker_x': '0.5',
+            'marker_y': '0.5'
+        }, follow_redirects=True)
+
+        # Assertions
+        self.assertEqual(response.status_code, 200)
+        updated_defect = Defect.query.get(defect_id)
+        self.assertEqual(updated_defect.description, new_description)
+        
+        marker = DefectMarker.query.filter_by(defect_id=defect_id).first()
+        self.assertIsNotNone(marker)
+        self.assertEqual(marker.drawing_id, self.drawing_id)
+        self.assertAlmostEqual(marker.x, 0.5)
+        self.assertAlmostEqual(marker.y, 0.5)
+        self.assertIn(b'Defect updated successfully!', response.data)
+
+    def test_update_existing_marker_when_editing_defect(self):
+        self.login_user(username='test_expert')
+
+        defect = Defect(project_id=self.project_id, description="Defect with marker", creator_id=self.expert_user_id, creation_date=datetime.now())
+        db.session.add(defect)
+        db.session.commit()
+        defect_id = defect.id
+
+        initial_marker = DefectMarker(defect_id=defect_id, drawing_id=self.drawing_id, x=0.2, y=0.2)
+        db.session.add(initial_marker)
+        db.session.commit()
+        marker_id = initial_marker.id
+
+        # Action: Edit defect and update marker coordinates
+        response = self.client.post(url_for('defect_detail', defect_id=defect_id), data={
+            'action': 'edit_defect',
+            'description': defect.description, # No change to description
+            'status': defect.status,         # No change to status
+            'drawing_id': str(self.drawing_id),
+            'marker_x': '0.8',
+            'marker_y': '0.8'
+        }, follow_redirects=True)
+
+        # Assertions
+        self.assertEqual(response.status_code, 200)
+        updated_marker = DefectMarker.query.get(marker_id)
+        self.assertIsNotNone(updated_marker)
+        self.assertAlmostEqual(updated_marker.x, 0.8)
+        self.assertAlmostEqual(updated_marker.y, 0.8)
+        self.assertEqual(DefectMarker.query.filter_by(defect_id=defect_id).count(), 1) # Still only one marker
+        self.assertIn(b'Defect updated successfully!', response.data)
+
+    def test_remove_marker_when_editing_defect(self):
+        self.login_user(username='test_expert')
+
+        defect = Defect(project_id=self.project_id, description="Defect to remove marker from", creator_id=self.expert_user_id, creation_date=datetime.now())
+        db.session.add(defect)
+        db.session.commit()
+        defect_id = defect.id
+
+        marker_to_remove = DefectMarker(defect_id=defect_id, drawing_id=self.drawing_id, x=0.3, y=0.3)
+        db.session.add(marker_to_remove)
+        db.session.commit()
+        marker_id = marker_to_remove.id
+        
+        self.assertIsNotNone(DefectMarker.query.get(marker_id))
+
+        # Action: Edit defect and remove marker by sending empty drawing_id
+        updated_description_for_removal_test = "Updated, marker removed"
+        response = self.client.post(url_for('defect_detail', defect_id=defect_id), data={
+            'action': 'edit_defect',
+            'description': updated_description_for_removal_test,
+            'status': 'open',
+            'drawing_id': '' # Empty drawing_id signals removal
+        }, follow_redirects=True)
+
+        # Assertions
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(DefectMarker.query.get(marker_id)) # Marker should be deleted
+        self.assertEqual(DefectMarker.query.filter_by(defect_id=defect_id).count(), 0)
+        
+        updated_defect_after_marker_removal = Defect.query.get(defect_id)
+        self.assertIsNotNone(updated_defect_after_marker_removal)
+        self.assertEqual(updated_defect_after_marker_removal.description, updated_description_for_removal_test)
+        self.assertIn(b'Defect updated successfully!', response.data)
+
+
+    def test_edit_defect_without_changing_marker(self):
+        self.login_user(username='test_expert')
+
+        defect = Defect(project_id=self.project_id, description="Defect with stable marker", creator_id=self.expert_user_id, creation_date=datetime.now())
+        db.session.add(defect)
+        db.session.commit()
+        defect_id = defect.id
+
+        original_x, original_y = 0.6, 0.6
+        marker = DefectMarker(defect_id=defect_id, drawing_id=self.drawing_id, x=original_x, y=original_y)
+        db.session.add(marker)
+        db.session.commit()
+        marker_id = marker.id
+
+        # Action: Edit defect description, but keep existing marker data
+        new_description_stable_marker = "New Description, marker stays"
+        response = self.client.post(url_for('defect_detail', defect_id=defect_id), data={
+            'action': 'edit_defect',
+            'description': new_description_stable_marker,
+            'status': defect.status,
+            'drawing_id': str(self.drawing_id), # Existing drawing_id
+            'marker_x': str(original_x),       # Existing X
+            'marker_y': str(original_y)        # Existing Y
+        }, follow_redirects=True)
+
+        # Assertions
+        self.assertEqual(response.status_code, 200)
+        updated_defect_stable_marker = Defect.query.get(defect_id)
+        self.assertEqual(updated_defect_stable_marker.description, new_description_stable_marker)
+
+        marker_after_edit = DefectMarker.query.get(marker_id)
+        self.assertIsNotNone(marker_after_edit)
+        self.assertEqual(marker_after_edit.drawing_id, self.drawing_id)
+        self.assertAlmostEqual(marker_after_edit.x, original_x)
+        self.assertAlmostEqual(marker_after_edit.y, original_y)
+        self.assertIn(b'Defect updated successfully!', response.data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit addresses three main issues and introduces enhancements:

1.  **Fix Defect Deletion:**
    *   I corrected the backend logic in the `defect_detail` route (`app.py`)
        to properly identify and process defect deletion requests.
        The condition was changed from checking `if 'delete' in request.form`
        to `if request.form.get('action') == 'delete_defect':`.

2.  **Improve Image Loading in Draw Tool:**
    *   I enhanced the JavaScript in `templates/draw.html` to make image
        loading more robust. This includes better checks for image
        dimensions (`naturalWidth`, `naturalHeight`) before rendering and
        improved error handling if an image fails to load.

3.  **Implement Add/Edit Marker in Defect Editing:**
    *   **Backend (`app.py`):**
        *   The `defect_detail` route now processes `drawing_id`, `marker_x`,
          and `marker_y` fields when a defect is edited.
        *   This allows creating a new `DefectMarker`, updating an existing one,
          or removing a marker if the drawing selection is cleared.
        *   I ensured that deleting a defect also deletes its associated marker.
    *   **Frontend (`templates/defect_detail.html`):**
        *   I added UI elements (drawing dropdown, PDF canvas, hidden fields)
          to the defect edit form, enabling you to add or modify a
          marker's location.
        *   I integrated JavaScript to manage PDF display, marker placement,
          and loading of existing marker data.

4.  **Add Unit Tests:**
    *   I introduced a new test file `tests/test_defect_marker_management.py`.
    *   I added tests for defect deletion (including marker cleanup) and
        for creating, updating, and removing markers during defect editing.

These changes resolve the reported issues regarding non-functional defect deletion, image loading problems in the draw tool, and the inability to add/edit marker locations after initial defect creation.