### PR TITLE
I've addressed the JavaScript error by preventing the redeclaration o…

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -36,7 +36,7 @@
         }
     </style>
     <script type="text/javascript">
-        const csrfToken = "{{ csrf_token() }}";
+        window.csrfTokenGlobal = "{{ csrf_token() }}"; // Changed to avoid const redeclaration
     </script>
     <script src="{{ url_for('static', filename='js/popup.js') }}"></script>
     <script>


### PR DESCRIPTION
…f `csrfToken`.

I resolved an "Uncaught SyntaxError: redeclaration of const csrfToken" that occurred on your draw page (`templates/draw.html`).

The error was caused by `const csrfToken` being declared globally in `templates/layout.html` and also locally in the script within `templates/draw.html`.

The fix modifies `templates/layout.html` to declare the global CSRF token as `window.csrfTokenGlobal` instead. This avoids the naming conflict with the lexically scoped `const csrfToken` in `draw.html`, allowing the draw page's script to function correctly without error.