### PR TITLE
Fix: Correct IndentationError in report generation logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -1550,10 +1550,10 @@ def generate_report(project_id):
                     lines.append(' '.join(current_line))
                 space_needed += len(lines) * line_height + 17.5  # Content + padding + half line offset
                 for attachment in comment.attachments:
-                if not attachment.file_path:
-                    logger.warning(f"Attachment ID {attachment.id} has a missing file path. Skipping space estimation for this image.")
-                    space_needed += 20
-                    continue
+                    if not attachment.file_path:
+                        logger.warning(f"Attachment ID {attachment.id} has a missing file path. Skipping space estimation for this image.")
+                        space_needed += 20
+                        continue
                     try:
                         img = PILImage.open(os.path.join(app.config['UPLOAD_FOLDER'], os.path.basename(attachment.file_path)))
                         img_width, img_height = img.size


### PR DESCRIPTION
This commit fixes an IndentationError that occurred in the `estimate_space_needed` function within `app.py`. The error was introduced in a previous commit aiming to make report generation more resilient to missing file paths.

The specific issue was an `if not attachment.file_path:` block (including its body for logging and continuing) that was not correctly indented under its parent `for attachment in comment.attachments:` loop within the section handling contractor comment attachments.

This commit corrects the indentation, ensuring the application can start and the report generation logic is syntactically correct.