### PR TITLE
Fix: Prevent UnboundLocalError in PDF report generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1830,6 +1830,8 @@ def generate_report(project_id): # Restored original signature
                 current_draw_y = y_after_item_comments
                 current_draw_y -= PADDING_SM # Space after item comments
 
+            y_position_before_image_processing = current_draw_y # <--- ADD THIS LINE
+
             # 4. Marked Drawing OR Attachments
             if entry[0] == 'defect': # Log before images/markers for defects
                 logger.info(f"add_defect_to_pdf: Defect ID {id_for_log}, current_draw_y before images/markers: {current_draw_y}")


### PR DESCRIPTION
Initializes the `y_position_before_image_processing` variable within the `add_defect_to_pdf` function before its potential use. This variable could previously be uninitialized if a defect had no marker data or incomplete marker data, leading to an UnboundLocalError.

This error would prevent the specific defect from being drawn correctly and could potentially affect the rendering of subsequent items in the report if not handled by the calling loop's error recovery.

With this change, defects that fall into this category should now be processed without this specific error, allowing their details to be included in the PDF report.