### PR TITLE
Here's the updated commit message:

### DIFF
--- a/templates/defect_detail.html
+++ b/templates/defect_detail.html
@@ -28,7 +28,10 @@
                 {% endif %}
             </div>
         </div>
-        <a href="{{ url_for('project_detail', project_id=project.id, filter=defect.status) }}" class="mt-3 sm:mt-0 bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back to Project</a>
+        <div>
+            <button type="button" id="editDefectButton" class="bg-blue-500 hover:bg-blue-700 text-white text-sm font-medium px-4 py-2 rounded-md shadow-sm mr-2">Edit Defect</button>
+            <a href="{{ url_for('project_detail', project_id=project.id, filter=defect.status) }}" class="mt-3 sm:mt-0 bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back to Project</a>
+        </div>
     </div>
 
     <!-- Wrapper for Defect Title and Defect Details Card -->
@@ -79,10 +82,14 @@
             {% if attachments %}
                 <div class="bg-white shadow-lg rounded-lg p-6 order-1 lg:order-none">
                     <h2 class="text-2xl font-semibold text-gray-700 mb-4">Attachments</h2>
+                    <button type="button" id="addNewAttachmentButton" class="mb-4 bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded">Add New Image</button>
                     <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
                         {% for attachment in attachments %}
-                            <div role="button" onclick="openImagePopup('{{ url_for('static', filename=attachment.file_path) }}', '{{ attachment.id }}', '/draw/');" class="group block rounded-lg overflow-hidden border border-gray-200 hover:border-primary transition-all duration-300 cursor-pointer">
-                                <img src="{{ url_for('static', filename=attachment.thumbnail_path) }}" alt="Attachment Thumbnail" class="w-full h-32 sm:h-40 object-cover group-hover:opacity-80 transition-opacity pointer-events-none">
+                            <div class="relative group">
+                                <div role="button" onclick="openImagePopup('{{ url_for('static', filename=attachment.file_path) }}', '{{ attachment.id }}', '/draw/');" class="block rounded-lg overflow-hidden border border-gray-200 hover:border-primary transition-all duration-300 cursor-pointer">
+                                    <img src="{{ url_for('static', filename=attachment.thumbnail_path) }}" alt="Attachment Thumbnail" class="w-full h-32 sm:h-40 object-cover group-hover:opacity-80 transition-opacity pointer-events-none">
+                                </div>
+                                <button type="button" data-attachment-id="{{ attachment.id }}" class="absolute top-1 right-1 bg-red-500 hover:bg-red-700 text-white text-xs font-bold py-1 px-2 rounded opacity-0 group-hover:opacity-100 transition-opacity delete-attachment-button">Delete</button>
                             </div>
                         {% endfor %}
                     </div>
@@ -117,10 +124,59 @@
 
         <!-- Right Column: Actions, Comments -->
         <div class="lg:w-1/3 space-y-6">
-            <!-- Actions Card (Edit, Delete) -->
-            {% if user_role in ['admin', 'expert'] or user_role == 'admin' %}
+            <!-- Comments List Card -->
             <div class="bg-white shadow-lg rounded-lg p-6">
-                <h2 class="text-2xl font-semibold text-gray-700 mb-4">Manage Defect</h2>
+                <h2 class="text-2xl font-semibold text-gray-700 mb-4">Comments</h2>
+                {% if comments %}
+                    <div class="space-y-4">
+                        {% for comment in comments %}
+                            <div class="p-4 bg-gray-50 rounded-lg border border-gray-200">
+                                <div class="flex justify-between items-center mb-1">
+                                    <p class="text-sm font-semibold text-primary">{{ comment.user.username }}</p>
+                                    <p class="text-xs text-gray-500">{{ comment.created_at.strftime('%Y-%m-%d %H:%M') }}</p>
+                                </div>
+                                <p class="text-sm text-gray-700 break-words">{{ comment.content }}</p>
+                                {% set comment_attachments = comment.attachments %}
+                                {% if comment_attachments %}
+                                    <div class="mt-3 grid grid-cols-2 sm:grid-cols-3 gap-2">
+                                        {% for attachment in comment_attachments %}
+                                            <div role="button" onclick="openImagePopup('{{ url_for('static', filename=attachment.file_path) }}', '{{ attachment.id }}', '/draw/');" class="group block rounded overflow-hidden border border-gray-100 hover:border-primary transition-all duration-300 cursor-pointer">
+                                                <img src="{{ url_for('static', filename=attachment.thumbnail_path) }}" alt="Comment Attachment" class="w-full h-20 sm:h-24 object-cover group-hover:opacity-80 transition-opacity pointer-events-none">
+                                            </div>
+                                        {% endfor %}
+                                    </div>
+                                {% endif %}
+                            </div>
+                        {% endfor %}
+                    </div>
+                {% else %}
+                    <p class="text-sm text-gray-500">No comments yet. Be the first to comment!</p>
+                {% endif %}
+            </div>
+
+            <!-- Add Comment Form Card -->
+            {% if user_role in ['admin', 'expert', 'worker'] %}
+                <div class="bg-white shadow-lg rounded-lg p-6">
+                    <h2 class="text-2xl font-semibold text-gray-700 mb-4">Add Comment</h2>
+                    <form method="POST" enctype="multipart/form-data" class="space-y-4">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token_value }}">
+                        <input type="hidden" name="action" value="add_comment">
+                        <div>
+                            <label for="comment_content" class="block text-sm font-medium text-gray-700">Your Comment</label>
+                            <textarea name="comment_content" id="comment_content" rows="4" class="mt-1 p-2 w-full border border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary" required></textarea>
+                        </div>
+                        <div>
+                            <label for="comment_photos" class="block text-sm font-medium text-gray-700">Attach Photos (Optional)</label>
+                            <input type="file" name="comment_photos" id="comment_photos" multiple accept="image/*" class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-white hover:file:bg-primary-hover file:cursor-pointer">
+                        </div>
+                        <button type="submit" class="w-full bg-primary hover:bg-primary-hover text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium">Submit Comment</button>
+                    </form>
+                </div>
+            {% endif %}
+            <!-- Hidden Edit Defect Form Container MOVED HERE -->
+            {% if user_role in ['admin', 'expert'] or user_role == 'admin' %}
+            <div id="editDefectFormContainer" class="hidden bg-white shadow-lg rounded-lg p-6 mb-6">
+                <h2 class="text-2xl font-semibold text-gray-700 mb-4">Edit Defect</h2>
                 {% if user_role in ['admin', 'expert'] %}
                     <form method="POST" class="space-y-4 mb-4"> {# Edit Defect Form #}
                         <input type="hidden" name="csrf_token" value="{{ csrf_token_value }}">
@@ -180,56 +236,6 @@
                 {% endif %}
             </div>
             {% endif %}
-            
-            <!-- Add Comment Form Card -->
-            {% if user_role in ['admin', 'expert', 'worker'] %}
-                <div class="bg-white shadow-lg rounded-lg p-6">
-                    <h2 class="text-2xl font-semibold text-gray-700 mb-4">Add Comment</h2>
-                    <form method="POST" enctype="multipart/form-data" class="space-y-4">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token_value }}">
-                        <input type="hidden" name="action" value="add_comment">
-                        <div>
-                            <label for="comment_content" class="block text-sm font-medium text-gray-700">Your Comment</label>
-                            <textarea name="comment_content" id="comment_content" rows="4" class="mt-1 p-2 w-full border border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary" required></textarea>
-                        </div>
-                        <div>
-                            <label for="comment_photos" class="block text-sm font-medium text-gray-700">Attach Photos (Optional)</label>
-                            <input type="file" name="comment_photos" id="comment_photos" multiple accept="image/*" class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-white hover:file:bg-primary-hover file:cursor-pointer">
-                        </div>
-                        <button type="submit" class="w-full bg-primary hover:bg-primary-hover text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium">Submit Comment</button>
-                    </form>
-                </div>
-            {% endif %}
-
-            <!-- Comments List Card -->
-            <div class="bg-white shadow-lg rounded-lg p-6">
-                <h2 class="text-2xl font-semibold text-gray-700 mb-4">Comments</h2>
-                {% if comments %}
-                    <div class="space-y-4">
-                        {% for comment in comments %}
-                            <div class="p-4 bg-gray-50 rounded-lg border border-gray-200">
-                                <div class="flex justify-between items-center mb-1">
-                                    <p class="text-sm font-semibold text-primary">{{ comment.user.username }}</p>
-                                    <p class="text-xs text-gray-500">{{ comment.created_at.strftime('%Y-%m-%d %H:%M') }}</p>
-                                </div>
-                                <p class="text-sm text-gray-700 break-words">{{ comment.content }}</p>
-                                {% set comment_attachments = comment.attachments %}
-                                {% if comment_attachments %}
-                                    <div class="mt-3 grid grid-cols-2 sm:grid-cols-3 gap-2">
-                                        {% for attachment in comment_attachments %}
-                                            <div role="button" onclick="openImagePopup('{{ url_for('static', filename=attachment.file_path) }}', '{{ attachment.id }}', '/draw/');" class="group block rounded overflow-hidden border border-gray-100 hover:border-primary transition-all duration-300 cursor-pointer">
-                                                <img src="{{ url_for('static', filename=attachment.thumbnail_path) }}" alt="Comment Attachment" class="w-full h-20 sm:h-24 object-cover group-hover:opacity-80 transition-opacity pointer-events-none">
-                                            </div>
-                                        {% endfor %}
-                                    </div>
-                                {% endif %}
-                            </div>
-                        {% endfor %}
-                    </div>
-                {% else %}
-                    <p class="text-sm text-gray-500">No comments yet. Be the first to comment!</p>
-                {% endif %}
-            </div>
         </div>
     </div>
 
@@ -389,6 +395,108 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     // Assuming workerSrc is set globally by the other script. If not, uncomment:
     // pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='js/pdf.worker.min.js') }}";
+
+    // Defect Edit Toggle & Attachment Management Script
+    const editDefectButton = document.getElementById('editDefectButton');
+    const editDefectFormContainer = document.getElementById('editDefectFormContainer');
+    const addNewAttachmentButton = document.getElementById('addNewAttachmentButton');
+    const deleteAttachmentButtons = document.querySelectorAll('.delete-attachment-button');
+    const csrfToken = '{{ csrf_token_value }}'; // Assuming csrf_token_value is passed to the template
+    const defectId = '{{ defect.id }}';
+
+    // 1. Edit Defect Toggle Functionality
+    if (editDefectButton && editDefectFormContainer) {
+        editDefectButton.addEventListener('click', function() {
+            const isHidden = editDefectFormContainer.classList.toggle('hidden');
+            if (isHidden) {
+                editDefectButton.textContent = 'Edit Defect';
+            } else {
+                editDefectButton.textContent = 'Cancel';
+            }
+        });
+    }
+
+    // 2. "Add New Image" Functionality
+    if (addNewAttachmentButton) {
+        let newAttachmentInput = document.getElementById('newAttachmentInput');
+        if (!newAttachmentInput) {
+            newAttachmentInput = document.createElement('input');
+            newAttachmentInput.type = 'file';
+            newAttachmentInput.id = 'newAttachmentInput';
+            newAttachmentInput.accept = 'image/*';
+            newAttachmentInput.classList.add('hidden');
+            document.body.appendChild(newAttachmentInput); // Add it to the body
+        }
+
+        addNewAttachmentButton.addEventListener('click', function() {
+            newAttachmentInput.click();
+        });
+
+        newAttachmentInput.addEventListener('change', function(event) {
+            const file = event.target.files[0];
+            if (file) {
+                const formData = new FormData();
+                formData.append('attachment_file', file);
+                formData.append('defect_id', defectId);
+                formData.append('csrf_token', csrfToken);
+
+                fetch(`/defect/${defectId}/attachment/add`, {
+                    method: 'POST',
+                    body: formData,
+                    // Flask-WTF typically checks CSRF token from FormData for AJAX if not using X-CSRFToken header
+                    // headers: { 'X-CSRFToken': csrfToken } // Example if using header-based CSRF
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        // alert('Attachment added successfully!'); // Optional alert
+                        location.reload(); // Reload to see the new attachment
+                    } else {
+                        alert('Error adding attachment: ' + (data.message || 'Unknown error'));
+                    }
+                })
+                .catch(error => {
+                    console.error('Error uploading attachment:', error);
+                    alert('Error uploading attachment. See console for details.');
+                });
+
+                // Reset file input for next selection
+                event.target.value = null;
+            }
+        });
+    }
+
+    // 3. "Delete Image" Functionality
+    deleteAttachmentButtons.forEach(button => {
+        button.addEventListener('click', function(event) {
+            const attachmentId = event.target.dataset.attachmentId;
+            if (confirm('Are you sure you want to delete this attachment?')) {
+                const formData = new FormData();
+                formData.append('attachment_id', attachmentId);
+                formData.append('defect_id', defectId); // Include defect_id for endpoint consistency
+                formData.append('csrf_token', csrfToken);
+
+                fetch(`/defect/${defectId}/attachment/delete`, {
+                    method: 'POST',
+                    body: formData,
+                    // headers: { 'X-CSRFToken': csrfToken }  // Example if using header-based CSRF
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        // alert('Attachment deleted successfully!'); // Optional alert
+                        event.target.closest('.relative.group').remove(); // Remove the attachment's div
+                    } else {
+                        alert('Error deleting attachment: ' + (data.message || 'Unknown error'));
+                    }
+                })
+                .catch(error => {
+                    console.error('Error deleting attachment:', error);
+                    alert('Error deleting attachment. See console for details.');
+                });
+            }
+        });
+    });
 
     const drawingSelectEdit = document.getElementById('drawing_id_edit');
     const drawingSectionEdit = document.getElementById('drawingSectionEdit');

--- a/tests/test_defect_marker_management.py
+++ b/tests/test_defect_marker_management.py
@@ -10,12 +10,21 @@ os.environ['WTF_CSRF_ENABLED'] = 'False'
 os.environ['SECRET_KEY'] = 'test-secret-key-for-sessions'
 os.environ['BCRYPT_LOG_ROUNDS'] = '4' # Speed up hashing for tests
 
-from app import app, db, User, Project, Drawing, Defect, DefectMarker, bcrypt, ProjectAccess
+from io import BytesIO
+from unittest.mock import patch, mock_open
 
-class TestDefectMarkerManagement(unittest.TestCase):
+from app import app, db, User, Project, Drawing, Defect, DefectMarker, Attachment, bcrypt, ProjectAccess # Added Attachment
+
+class TestDefectMarkerManagement(unittest.TestCase): # Will add Attachment tests here
 
     def setUp(self):
         self.app = app
+        # Configure a separate test upload folder if not relying entirely on mocks
+        # For now, we will mock filesystem interactions for attachments.
+        # self.app.config['UPLOAD_FOLDER'] = 'tests/test_uploads'
+        # os.makedirs(self.app.config['UPLOAD_FOLDER'], exist_ok=True)
+        # os.makedirs(os.path.join(self.app.config['UPLOAD_FOLDER'], 'thumbnails'), exist_ok=True)
+
         self.client = self.app.test_client()
         self.app_context = self.app.app_context()
         self.app_context.push()
@@ -24,10 +33,12 @@ class TestDefectMarkerManagement(unittest.TestCase):
         # Create users with different roles
         admin_user = User(username='test_admin', role='admin', password=bcrypt.generate_password_hash('password').decode('utf-8'))
         expert_user = User(username='test_expert', role='expert', password=bcrypt.generate_password_hash('password').decode('utf-8'))
-        db.session.add_all([admin_user, expert_user])
+        worker_user = User(username='test_worker', role='worker', password=bcrypt.generate_password_hash('password').decode('utf-8'))
+        db.session.add_all([admin_user, expert_user, worker_user])
         db.session.commit()
         self.admin_user_id = admin_user.id
         self.expert_user_id = expert_user.id
+        self.worker_user_id = worker_user.id
         
         # Create a project
         project = Project(name="Test Project")
@@ -38,7 +49,8 @@ class TestDefectMarkerManagement(unittest.TestCase):
         # Grant access to users for the project
         admin_access = ProjectAccess(user_id=self.admin_user_id, project_id=self.project_id, role='admin')
         expert_access = ProjectAccess(user_id=self.expert_user_id, project_id=self.project_id, role='expert')
-        db.session.add_all([admin_access, expert_access])
+        worker_access = ProjectAccess(user_id=self.worker_user_id, project_id=self.project_id, role='worker')
+        db.session.add_all([admin_access, expert_access, worker_access])
         db.session.commit()
 
         # Create a drawing
@@ -52,12 +64,20 @@ class TestDefectMarkerManagement(unittest.TestCase):
         db.session.remove()
         db.drop_all()
         self.app_context.pop()
+        # Clean up test upload folder if it was created
+        # if os.path.exists(self.app.config['UPLOAD_FOLDER']) and self.app.config['UPLOAD_FOLDER'] == 'tests/test_uploads':
+        #     import shutil
+        #     shutil.rmtree(self.app.config['UPLOAD_FOLDER'])
+
 
     def login_user(self, username='test_admin', password='password'):
         return self.client.post(url_for('login'), data=dict(
             username=username,
             password=password
         ), follow_redirects=True)
+
+    def _create_dummy_file_bytes(self, filename="test_image.png", content=b"fake image data"):
+        return BytesIO(content), filename
 
     def test_delete_defect_with_marker(self):
         self.login_user(username='test_admin') # Admin role needed for deletion
@@ -224,6 +244,235 @@ class TestDefectMarkerManagement(unittest.TestCase):
         self.assertAlmostEqual(marker_after_edit.x, original_x)
         self.assertAlmostEqual(marker_after_edit.y, original_y)
         self.assertIn(b'Defect updated successfully!', response.data)
+
+    # --- Defect Attachment Tests ---
+
+    @patch('app.create_thumbnail')
+    @patch('app.ensure_thumbnail_directory')
+    @patch('os.chmod') # To prevent chmod errors on BytesIO during save mock
+    @patch('builtins.open', new_callable=mock_open) # Mock open for file.save()
+    def test_add_attachment_successfully_as_worker(self, mock_file_open, mock_os_chmod, mock_ensure_thumb_dir, mock_create_thumb):
+        self.login_user(username='test_worker', password='password')
+
+        defect = Defect(project_id=self.project_id, description="Defect for attachment", creator_id=self.worker_user_id, creation_date=datetime.now())
+        db.session.add(defect)
+        db.session.commit()
+
+        dummy_file_bytes, dummy_filename = self._create_dummy_file_bytes(filename="test_upload.jpg")
+
+        data = {
+            'attachment_file': (dummy_file_bytes, dummy_filename),
+            # 'csrf_token': 'test-csrf-token' # WTF_CSRF_ENABLED is False
+        }
+
+        # Mock return value for ensure_thumbnail_directory if it's used to construct paths directly
+        mock_ensure_thumb_dir.return_value = os.path.join(self.app.config['UPLOAD_FOLDER'], 'thumbnails')
+
+        response = self.client.post(
+            url_for('add_defect_attachment', defect_id=defect.id),
+            data=data,
+            content_type='multipart/form-data',
+            follow_redirects=True
+        )
+
+        self.assertEqual(response.status_code, 200)
+        json_response = response.json
+        self.assertTrue(json_response.get('success'))
+        self.assertIn('Attachment added successfully', json_response.get('message', ''))
+
+        attachment = Attachment.query.filter_by(defect_id=defect.id).first()
+        self.assertIsNotNone(attachment)
+        self.assertIn(dummy_filename, attachment.file_path)
+        self.assertTrue(attachment.file_path.startswith('images/'))
+        self.assertTrue(attachment.thumbnail_path.startswith('images/thumbnails/thumb_'))
+        self.assertIn(dummy_filename, attachment.thumbnail_path)
+
+        # Assert that create_thumbnail was called (or the mocks for file saving within it)
+        mock_ensure_thumb_dir.assert_called_once()
+        # The actual save path for original is app.config['UPLOAD_FOLDER'] + unique_filename_base
+        # The actual save path for thumbnail is thumbnail_dir + thumbnail_filename_base
+        # We need to ensure create_thumbnail is called with appropriate paths.
+        # Since file.save is mocked by mock_open, we check if it was called.
+        mock_file_open.assert_called() # Check if BytesIO.save (which is `file.save` in app code) was called by werkzeug's FileStorage save
+        mock_create_thumb.assert_called_once()
+        # Example of asserting arguments if needed:
+        # args_create_thumb, _ = mock_create_thumb.call_args
+        # self.assertTrue(args_create_thumb[0].endswith(dummy_filename)) # original_save_path
+        # self.assertTrue(args_create_thumb[1].startswith(os.path.join(self.app.config['UPLOAD_FOLDER'], 'thumbnails', 'thumb_'))) # thumbnail_save_path
+
+    @patch('app.create_thumbnail')
+    @patch('app.ensure_thumbnail_directory')
+    @patch('os.chmod')
+    @patch('builtins.open', new_callable=mock_open)
+    def test_add_attachment_invalid_file_type(self, mock_file_open, mock_os_chmod, mock_ensure_thumb_dir, mock_create_thumb):
+        self.login_user(username='test_worker', password='password')
+
+        defect = Defect(project_id=self.project_id, description="Defect for invalid attachment", creator_id=self.worker_user_id, creation_date=datetime.now())
+        db.session.add(defect)
+        db.session.commit()
+
+        dummy_file_bytes, dummy_filename = self._create_dummy_file_bytes(filename="test_invalid.txt", content=b"this is a text file")
+
+        data = {
+            'attachment_file': (dummy_file_bytes, dummy_filename)
+        }
+
+        response = self.client.post(
+            url_for('add_defect_attachment', defect_id=defect.id),
+            data=data,
+            content_type='multipart/form-data',
+            follow_redirects=True
+        )
+
+        self.assertEqual(response.status_code, 400) # Expecting Bad Request
+        json_response = response.json
+        self.assertFalse(json_response.get('success'))
+        self.assertEqual(json_response.get('error'), 'File type not allowed.')
+
+        attachment_count = Attachment.query.filter_by(defect_id=defect.id).count()
+        self.assertEqual(attachment_count, 0)
+
+        mock_create_thumb.assert_not_called()
+        mock_ensure_thumb_dir.assert_not_called() # Should not be called if file type check fails early
+
+    @patch('os.remove')
+    @patch('os.path.exists')
+    def test_delete_attachment_successfully_as_admin(self, mock_path_exists, mock_os_remove):
+        self.login_user(username='test_admin', password='password')
+
+        defect = Defect(project_id=self.project_id, description="Defect for attachment deletion", creator_id=self.admin_user_id, creation_date=datetime.now())
+        db.session.add(defect)
+        db.session.commit()
+
+        # Create a dummy attachment record and simulate its files existing
+        dummy_file_name = "test_delete_image.jpg"
+        dummy_thumb_name = "thumb_test_delete_image.jpg"
+
+        # Relative paths as stored in DB
+        db_file_path = os.path.join('images', dummy_file_name)
+        db_thumbnail_path = os.path.join('images', 'thumbnails', dummy_thumb_name)
+
+        attachment = Attachment(
+            defect_id=defect.id,
+            file_path=db_file_path,
+            thumbnail_path=db_thumbnail_path
+        )
+        db.session.add(attachment)
+        db.session.commit()
+        attachment_id = attachment.id
+
+        # Mock os.path.exists to return True for these specific paths
+        def side_effect_path_exists(path):
+            if path == os.path.join(self.app.static_folder, db_file_path) or \
+               path == os.path.join(self.app.static_folder, db_thumbnail_path):
+                return True
+            return False
+        mock_path_exists.side_effect = side_effect_path_exists
+
+        data = {
+            'attachment_id': attachment_id,
+            # 'csrf_token': 'test-csrf-token' # WTF_CSRF_ENABLED is False
+        }
+
+        response = self.client.post(
+            url_for('delete_defect_attachment_json', defect_id=defect.id), # Route name from app.py
+            data=data,
+            follow_redirects=True
+        )
+
+        self.assertEqual(response.status_code, 200)
+        json_response = response.json
+        self.assertTrue(json_response.get('success'))
+        self.assertIn('Attachment deleted successfully', json_response.get('message', ''))
+
+        self.assertIsNone(Attachment.query.get(attachment_id))
+
+        # Check that os.remove was called for both files
+        expected_remove_calls = [
+            os.path.join(self.app.static_folder, db_file_path),
+            os.path.join(self.app.static_folder, db_thumbnail_path)
+        ]
+        # Check if mock_os_remove.call_args_list contains calls with these arguments
+        # This is a bit more robust than checking call_count if order might vary or other calls happen
+        called_paths = [call_args[0][0] for call_args in mock_os_remove.call_args_list]
+        for expected_path in expected_remove_calls:
+            self.assertIn(expected_path, called_paths)
+        self.assertEqual(mock_os_remove.call_count, 2)
+
+    @patch('os.remove')
+    @patch('os.path.exists')
+    def test_delete_attachment_role_denied_as_worker(self, mock_path_exists, mock_os_remove):
+        self.login_user(username='test_worker', password='password') # Worker role
+
+        defect = Defect(project_id=self.project_id, description="Defect for role test", creator_id=self.admin_user_id, creation_date=datetime.now())
+        db.session.add(defect)
+        db.session.commit()
+
+        attachment = Attachment(
+            defect_id=defect.id,
+            file_path='images/dont_delete.jpg',
+            thumbnail_path='images/thumbnails/thumb_dont_delete.jpg'
+        )
+        db.session.add(attachment)
+        db.session.commit()
+        attachment_id = attachment.id
+
+        data = {
+            'attachment_id': attachment_id,
+        }
+
+        response = self.client.post(
+            url_for('delete_defect_attachment_json', defect_id=defect.id),
+            data=data,
+            follow_redirects=True
+        )
+
+        self.assertEqual(response.status_code, 403) # Forbidden
+        json_response = response.json
+        self.assertFalse(json_response.get('success'))
+        self.assertIn('Permission denied', json_response.get('error', ''))
+
+        self.assertIsNotNone(Attachment.query.get(attachment_id)) # Still exists
+        mock_os_remove.assert_not_called()
+
+    def test_delete_non_existent_attachment(self):
+        self.login_user(username='test_admin')
+        defect = Defect(project_id=self.project_id, description="Defect for non-existent attachment test", creator_id=self.admin_user_id)
+        db.session.add(defect)
+        db.session.commit()
+
+        data = {'attachment_id': 99999} # Non-existent ID
+        response = self.client.post(url_for('delete_defect_attachment_json', defect_id=defect.id), data=data)
+
+        self.assertEqual(response.status_code, 404) # Not Found
+        json_response = response.json
+        self.assertFalse(json_response.get('success'))
+        self.assertIn('Attachment not found', json_response.get('error', ''))
+
+    def test_delete_attachment_from_wrong_defect(self):
+        self.login_user(username='test_admin')
+
+        defect1 = Defect(project_id=self.project_id, description="Defect 1", creator_id=self.admin_user_id)
+        defect2 = Defect(project_id=self.project_id, description="Defect 2", creator_id=self.admin_user_id)
+        db.session.add_all([defect1, defect2])
+        db.session.commit()
+
+        attachment_defect1 = Attachment(defect_id=defect1.id, file_path="file1.jpg", thumbnail_path="thumb1.jpg")
+        db.session.add(attachment_defect1)
+        db.session.commit()
+
+        data = {'attachment_id': attachment_defect1.id}
+        # Try to delete attachment_defect1 using defect2's ID in the URL
+        response = self.client.post(url_for('delete_defect_attachment_json', defect_id=defect2.id), data=data)
+
+        self.assertEqual(response.status_code, 404) # Attachment not found *for this defect*
+        json_response = response.json
+        self.assertFalse(json_response.get('success'))
+        self.assertIn('Attachment not found or does not belong to this defect', json_response.get('error', ''))
+
+        # Ensure attachment still exists and is linked to defect1
+        self.assertIsNotNone(Attachment.query.get(attachment_defect1.id))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Refactor defect detail page and add attachment management

This commit implements several enhancements to the defect detail page:

1.  **Revised Edit Defect UI:**
    *   I removed the "Manage Defect" card.
    *   I added an "Edit Defect" button in the header, which toggles the visibility of an edit form.
    *   The edit form (for description, status, location) now appears in the right-hand sidebar when you click "Edit Defect".

2.  **Comment Card Reordering:**
    *   The "Comments" list card now appears above the "Add Comment" form card for better readability.

3.  **Attachment Management:**
    *   I added an "Add New Image" button to the "Attachments" card.
    *   I added "Delete" buttons to each attachment, visible on hover.
    *   I implemented corresponding JavaScript for client-side interactions (file selection, AJAX requests for add/delete).
    *   I added backend Flask routes (`/defect/<id>/attachment/add` and `/defect/<id>/attachment/delete`) to handle file uploads (including thumbnail generation) and deletions.
    *   I ensured role-based access control for these operations.
    *   I standardized thumbnail creation and storage paths across the application.

4.  **Testing:**
    *   I added comprehensive unit tests for the new attachment management backend logic, covering successful operations, role permissions, invalid inputs, and error handling. Mocking was used for file system interactions.

5.  **Styling:**
    *   I adjusted Tailwind CSS classes for new UI elements to ensure consistency with the existing application style.