### PR TITLE
Refine defect detail card layout for status and dates

### DIFF
--- a/templates/defect_detail.html
+++ b/templates/defect_detail.html
@@ -31,7 +31,7 @@
         </div>
 
         <!-- Defect Status, Creator, Dates -->
-        <div class="mt-4 grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+        <div class="mt-4 grid grid-cols-3 gap-x-4 gap-y-2">
             <div>
                 <dt class="text-sm font-medium text-gray-500">Status</dt>
                 <dd class="mt-1" id="statusContainer"> {# Re-using statusContainer ID for JS compatibility #}


### PR DESCRIPTION
This commit updates the defect information card on the defect detail page to display Status, Created By, and Creation Date in a single horizontal line on both mobile and desktop screens.

The grid layout for these elements has been changed to `grid-cols-3` with adjusted gap spacing to ensure they align as requested. If the "Close Date" is present, it will wrap to the next line. This enhances the compactness and readability of this information section.