### PR TITLE
Feat: Implement PDF thumbnail generation and display for defect attac…

### DIFF
--- a/templates/defect_detail.html
+++ b/templates/defect_detail.html
@@ -83,30 +83,34 @@
                         {% for attachment in attachments %}
                             <div class="relative group">
                                 <div role="button"
-                                     {# onclick will be updated later to handle PDFs differently #}
-                                     onclick="openImagePopup('{{ url_for('static', filename=attachment.file_path) }}', '{{ attachment.id }}', '/draw/');"
+                                     {% if attachment.mime_type == 'application/pdf' %}
+                                         onclick="openPdfPopup('{{ url_for('static', filename=attachment.file_path) }}');"
+                                     {% else %}
+                                         onclick="openImagePopup('{{ url_for('static', filename=attachment.file_path) }}', '{{ attachment.id }}', '/draw/');"
+                                     {% endif %}
                                      class="block rounded-lg overflow-hidden border border-gray-200 hover:border-primary transition-all duration-300 cursor-pointer">
 
                                     {% if attachment.mime_type == 'application/pdf' %}
                                         {% if attachment.thumbnail_path %}
                                             <img src="{{ url_for('static', filename=attachment.thumbnail_path) }}" alt="PDF Thumbnail" class="w-full h-32 sm:h-40 object-contain group-hover:opacity-80 transition-opacity pointer-events-none">
                                         {% else %}
-                                            {# SVG Icon and text as placeholder for PDF #}
-                                            <div class="w-full h-32 sm:h-40 flex flex-col items-center justify-center bg-gray-100 text-gray-400 group-hover:opacity-80 transition-opacity">
-                                                <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 3v4a1 1 0 001 1h4" /></svg>
-                                                <span class="mt-2 text-sm">PDF Document</span>
+                                            {# Generic PDF icon/placeholder - using SVG for self-containment #}
+                                            <div class="w-full h-32 sm:h-40 flex flex-col items-center justify-center bg-gray-100 text-gray-400 group-hover:opacity-80 transition-opacity p-2">
+                                                <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 3v4a1 1 0 001 1h4" /></svg>
+                                                <span class="mt-1 text-xs text-center">PDF Document</span>
                                             </div>
                                         {% endif %}
                                     {% elif attachment.mime_type and attachment.mime_type.startswith('image/') %}
-                                        <img src="{{ url_for('static', filename=attachment.thumbnail_path) }}" alt="Attachment Thumbnail" class="w-full h-32 sm:h-40 object-cover group-hover:opacity-80 transition-opacity pointer-events-none">
+                                        <img src="{{ url_for('static', filename=attachment.thumbnail_path) }}" alt="Image Thumbnail" class="w-full h-32 sm:h-40 object-cover group-hover:opacity-80 transition-opacity pointer-events-none">
                                     {% else %}
-                                         {# Fallback for unknown mime_types or old records without mime_type but with a thumbnail (likely images) #}
+                                         {# Fallback for unknown mime_types or old records without mime_type but with a thumbnail (likely images before mime_type was stored) #}
                                          {% if attachment.thumbnail_path %}
                                             <img src="{{ url_for('static', filename=attachment.thumbnail_path) }}" alt="Attachment" class="w-full h-32 sm:h-40 object-cover group-hover:opacity-80 transition-opacity pointer-events-none">
                                          {% else %}
-                                            <div class="w-full h-32 sm:h-40 flex flex-col items-center justify-center bg-gray-100 text-gray-400 group-hover:opacity-80 transition-opacity">
-                                                <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" /></svg>
-                                                <span class="mt-2 text-sm">File</span>
+                                            {# Generic file icon/placeholder if no thumbnail and unknown type #}
+                                            <div class="w-full h-32 sm:h-40 flex flex-col items-center justify-center bg-gray-100 text-gray-400 group-hover:opacity-80 transition-opacity p-2">
+                                                <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd" /></svg>
+                                                <span class="mt-1 text-xs text-center">File</span>
                                             </div>
                                          {% endif %}
                                     {% endif %}


### PR DESCRIPTION
…hments

This commit introduces support for generating and displaying thumbnails for PDF attachments associated with defects.

Key changes:
- Backend (`app.py`, in `add_defect_attachment` route):
  - Integrates `pdf2image` (with Poppler dependency) to create PNG thumbnails from the first page of uploaded PDF files.
  - Thumbnails are saved to `static/uploads/attachments_pdf_thumbs/`.
  - The relative path to the thumbnail is stored in `Attachment.thumbnail_path`.
  - Includes error handling for thumbnail generation.
  - Updates `ensure_attachment_paths` to manage PDF thumbnail directories.
  - Sets file permissions for saved PDFs and thumbnails.
- Frontend (`templates/defect_detail.html`):
  - Updated the defect attachments display loop to:
    - Show generated PDF thumbnails (using `object-contain`) if available.
    - Show a generic PDF icon placeholder if a PDF thumbnail is missing.
    - Continue showing image thumbnails (using `object-cover`) as before.
    - Includes a fallback for unknown attachment types.
  - (Also re-verified that `onclick` events correctly route to `openPdfPopup` for PDFs and `openImagePopup` for images).
- Defect Detail Page Header:
  - Corrected the main header to ensure the "Back" button is on the right of the project title, consistent with recent feedback from you.

This work sets the stage for full PDF viewing capabilities and improves the visual representation of PDF attachments.