### PR TITLE
Fix: Correct field name for comment image attachments

### DIFF
--- a/app.py
+++ b/app.py
@@ -800,8 +800,8 @@ def defect_detail(defect_id):
                     db.session.add(comment)
                     db.session.commit() # Commit comment to get comment.id for attachments
                     attachment_ids = []
-                    if 'photos' in request.files:
-                        files = request.files.getlist('photos')
+                    if 'comment_photos' in request.files:
+                        files = request.files.getlist('comment_photos')
                         for file in files:
                             if file and allowed_file(file.filename):
                                 timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')


### PR DESCRIPTION
The backend was attempting to retrieve uploaded images for comments from the field name 'photos' instead of the correct field name 'comment_photos' as defined in the HTML form.

This commit updates the `defect_detail` route in `app.py` to use `request.files.getlist('comment_photos')` and `if 'comment_photos' in request.files` to correctly process images attached to comments.