### PR TITLE
Fix: Resolve NameError and correct field name for comment image attac…

### DIFF
--- a/app.py
+++ b/app.py
@@ -264,6 +264,14 @@ def load_user(user_id):
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in app.config['ALLOWED_EXTENSIONS']
 
+def ensure_thumbnail_directory():
+    # app refers to the Flask app instance, UPLOAD_FOLDER is 'static/images'
+    thumbnail_dir = os.path.join(app.config['UPLOAD_FOLDER'], 'thumbnails')
+    if not os.path.exists(thumbnail_dir):
+        os.makedirs(thumbnail_dir, exist_ok=True)
+        os.chmod(thumbnail_dir, 0o755)  # Ensure correct permissions
+    return thumbnail_dir
+
 # Helper function to ensure specific attachment subdirectories exist
 def ensure_attachment_paths(subfolder_name):
     # Base directory for all uploads, relative to 'static'


### PR DESCRIPTION
…hments

This commit addresses two issues related to adding images to comments:

1. Defines the `ensure_thumbnail_directory` helper function globally in `app.py`. This function was being called in the comment attachment processing logic but was not defined, leading to a `NameError`.

2. Corrects the field name used to access uploaded comment images. The code was looking for `photos` instead of `comment_photos` from the form submission.

With these changes, images attached to comments should now be processed, saved, and displayed correctly.