### PR TITLE
Fix: Redirect to Checklists tab after adding a checklist

### DIFF
--- a/app.py
+++ b/app.py
@@ -1277,7 +1277,7 @@ def add_checklist(project_id):
             db.session.add(checklist_item)
         db.session.commit()
         flash('Checklist added successfully!', 'success')
-        return redirect(url_for('project_detail', project_id=project_id))
+        return redirect(url_for('project_detail', project_id=project_id, _anchor='checklists'))
     return render_template('add_checklist.html', project=project, templates=templates)
 
 @app.route('/checklist/<int:checklist_id>', methods=['GET', 'POST'])
@@ -1391,7 +1391,7 @@ def delete_checklist(checklist_id):
     db.session.delete(checklist)
     db.session.commit()
     flash('Checklist deleted successfully!', 'success')
-    return redirect(url_for('project_detail', project_id=project_id))
+    return redirect(url_for('project_detail', project_id=project_id, _anchor='checklists'))
 
 @app.route('/checklist/<int:checklist_id>/delete_attachment/<int:attachment_id>', methods=['POST'])
 @login_required


### PR DESCRIPTION
Previously, after adding a new checklist, you were redirected to the default 'Defects' tab on the project detail page. This change modifies the redirect in the `add_checklist` function to include `_anchor='checklists'`, ensuring you are taken directly to the 'Checklists' tab, improving your experience.