### PR TITLE
Update checklist detail header to match defect detail page

### DIFF
--- a/templates/checklist_detail.html
+++ b/templates/checklist_detail.html
@@ -2,13 +2,13 @@
 {% block title %}Checklist: {{ checklist.name }}{% endblock %}
 {% block content %}
 <div class="container mx-auto py-8 px-4 sm:px-6 lg:px-8">
-    <div class="flex flex-col sm:flex-row justify-between items-center mb-6 pb-4 border-b border-gray-300">
-        <div>
-            <h1 class="text-3xl font-bold text-gray-800">Checklist: <span class="text-primary">{{ checklist.name }}</span></h1>
-            <p class="text-sm text-gray-600">Project: <a href="{{ url_for('project_detail', project_id=checklist.project.id) }}" class="text-primary hover:underline">{{ checklist.project.name }}</a></p>
-        </div>
-        <a href="{{ url_for('project_detail', project_id=checklist.project.id) }}" class="mt-3 sm:mt-0 bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back to Project</a>
-    </div>
+   <!-- Header: Project Title and Back Button -->
+   <div class="flex flex-row justify-between items-center mb-6 pb-4 border-b border-gray-300">
+       <h1 class="text-3xl font-bold text-gray-800">
+           Project: <span class="text-primary">{{ checklist.project.name }}</span>
+       </h1>
+       <a href="{{ url_for('project_detail', project_id=checklist.project.id) }}" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back</a>
+   </div>
 
     {% if items %}
         <form method="POST" action="{{ url_for('checklist_detail', checklist_id=checklist.id) }}" class="bg-white p-6 sm:p-8 shadow-xl rounded-xl space-y-6">


### PR DESCRIPTION
The checklist detail page header has been updated to display the project name prominently on the left and a 'Back' button on the right. This makes the UI consistent with the defect detail page.