### PR TITLE
Fix: Redirect to Checklists tab from checklist detail

### DIFF
--- a/app.py
+++ b/app.py
@@ -516,6 +516,7 @@ def project_detail(project_id):
         flash('You do not have access to this project.', 'error')
         return redirect(url_for('index'))
     filter_status = request.args.get('filter', 'All')
+    tab = request.args.get('_anchor')
     defects_query = Defect.query.filter_by(project_id=project_id)
     if filter_status == 'Open':
         defects = defects_query.filter_by(status='open').all()
@@ -567,7 +568,7 @@ def project_detail(project_id):
         checklist.completed_items = completed_items
 
         filtered_checklists.append(checklist)
-    return render_template('project_detail.html', project=project, defects=defects, checklists=filtered_checklists, filter_status=filter_status, user_role=access.role)
+    return render_template('project_detail.html', project=project, defects=defects, checklists=filtered_checklists, filter_status=filter_status, user_role=access.role, tab=tab)
 
 @app.route('/project/<int:project_id>/add_drawing', methods=['GET', 'POST'])
 @login_required

--- a/templates/checklist_detail.html
+++ b/templates/checklist_detail.html
@@ -7,7 +7,7 @@
        <h1 class="text-3xl font-bold text-gray-800">
            Project: <span class="text-primary">{{ checklist.project.name }}</span>
        </h1>
-       <a href="{{ url_for('project_detail', project_id=checklist.project.id) }}" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back</a>
+       <a href="{{ url_for('project_detail', project_id=checklist.project.id, _anchor='checklists') }}" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back</a>
    </div>
 
     {% if items %}

--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -403,18 +403,36 @@ document.addEventListener('DOMContentLoaded', function () {
         switchTab(checklistsTabButton, checklistsPane, defectsTabButton, defectsPane);
     });
 
-    // Check for URL hash and switch to checklists tab if necessary
-    if (window.location.hash === '#checklists') {
-        // Call the existing switchTab function to activate the checklists tab
-        // Ensure variables like checklistsTabButton, checklistsPane, etc., are accessible here
-        // or simulate a click if that's easier and already set up.
-        // Based on the provided script, simulating a click is straightforward:
-        checklistsTabButton.click();
+    // Function to update URL without reloading page
+    function updateURLAnchor(tabName) {
+        const currentUrl = new URL(window.location.href);
+        if (tabName && tabName !== 'defects') { // Assuming 'defects' is default, so no anchor needed
+            currentUrl.searchParams.set('_anchor', tabName);
+        } else {
+            currentUrl.searchParams.delete('_anchor'); // Remove if 'defects' or no tab
+        }
+        history.replaceState({}, '', currentUrl.toString());
+    }
+
+    // Event listener for Defects tab
+    defectsTabButton.addEventListener('click', function () {
+        switchTab(defectsTabButton, defectsPane, checklistsTabButton, checklistsPane);
+        updateURLAnchor('defects');
+    });
+
+    // Event listener for Checklists tab
+    checklistsTabButton.addEventListener('click', function () {
+        switchTab(checklistsTabButton, checklistsPane, defectsTabButton, defectsPane);
+        updateURLAnchor('checklists');
+    });
+
+    // Initial tab setup based on 'tab' variable from Flask
+    const initialTab = "{{ tab or 'defects' }}"; // Default to 'defects' if tab is not provided
+
+    if (initialTab === 'checklists') {
+        checklistsTabButton.click(); // This will also call updateURLAnchor via the click listener
     } else {
-        // Default to defects tab if no specific hash or a different one
-        // The existing code already defaults to the defects tab by styling,
-        // so explicitly clicking it ensures all logic (like button/filter visibility) runs.
-        defectsTabButton.click();
+        defectsTabButton.click(); // This will also call updateURLAnchor
     }
 });
 </script>


### PR DESCRIPTION
This commit addresses an issue where the "Back" button on the checklist detail page would redirect to the "Defects" tab on the project detail page by default.

The following changes were made:
- The `project_detail` route in `app.py` was updated to accept an `_anchor` parameter to specify the active tab.
- The "Back" button in `templates/checklist_detail.html` was modified to include `_anchor='checklists'` in its URL.
- JavaScript in `templates/project_detail.html` was updated to read the `_anchor` parameter from the URL and activate the corresponding tab. If no `_anchor` is present, it defaults to the "Defects" tab.

This ensures that when you click the "Back" button on the checklist detail page, you are correctly navigated to the "Checklists" tab on the project detail page.