### PR TITLE
Fix: Redirect to Checklists tab using URL fragment

### DIFF
--- a/app.py
+++ b/app.py
@@ -516,7 +516,6 @@ def project_detail(project_id):
         flash('You do not have access to this project.', 'error')
         return redirect(url_for('index'))
     filter_status = request.args.get('filter', 'All')
-    tab = request.args.get('_anchor')
     defects_query = Defect.query.filter_by(project_id=project_id)
     if filter_status == 'Open':
         defects = defects_query.filter_by(status='open').all()
@@ -568,7 +567,7 @@ def project_detail(project_id):
         checklist.completed_items = completed_items
 
         filtered_checklists.append(checklist)
-    return render_template('project_detail.html', project=project, defects=defects, checklists=filtered_checklists, filter_status=filter_status, user_role=access.role, tab=tab)
+    return render_template('project_detail.html', project=project, defects=defects, checklists=filtered_checklists, filter_status=filter_status, user_role=access.role)
 
 @app.route('/project/<int:project_id>/add_drawing', methods=['GET', 'POST'])
 @login_required

--- a/templates/checklist_detail.html
+++ b/templates/checklist_detail.html
@@ -7,7 +7,7 @@
        <h1 class="text-3xl font-bold text-gray-800">
            Project: <span class="text-primary">{{ checklist.project.name }}</span>
        </h1>
-       <a href="{{ url_for('project_detail', project_id=checklist.project.id, _anchor='checklists') }}" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back</a>
+       <a href="{{ url_for('project_detail', project_id=checklist.project.id) }}#checklists" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back</a>
    </div>
 
     {% if items %}

--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -394,46 +394,38 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     // Event listener for Defects tab
-    defectsTabButton.addEventListener('click', function () {
+    defectsTabButton.addEventListener('click', function (event) {
+        // event.preventDefault(); // Not strictly needed for button elements, but good practice if they were <a>
         switchTab(defectsTabButton, defectsPane, checklistsTabButton, checklistsPane);
+        window.location.hash = 'defects';
     });
 
     // Event listener for Checklists tab
-    checklistsTabButton.addEventListener('click', function () {
+    checklistsTabButton.addEventListener('click', function (event) {
+        // event.preventDefault();
         switchTab(checklistsTabButton, checklistsPane, defectsTabButton, defectsPane);
+        window.location.hash = 'checklists';
     });
 
-    // Function to update URL without reloading page
-    function updateURLAnchor(tabName) {
-        const currentUrl = new URL(window.location.href);
-        if (tabName && tabName !== 'defects') { // Assuming 'defects' is default, so no anchor needed
-            currentUrl.searchParams.set('_anchor', tabName);
+    // Initial tab setup based on URL hash
+    function activateTabFromHash() {
+        const hash = window.location.hash;
+        if (hash === '#checklists') {
+            // Directly call switchTab to avoid recursive hash change if click() is used
+            switchTab(checklistsTabButton, checklistsPane, defectsTabButton, defectsPane);
         } else {
-            currentUrl.searchParams.delete('_anchor'); // Remove if 'defects' or no tab
+            // Default to defects tab (includes #defects, empty hash, or any other hash)
+            switchTab(defectsTabButton, defectsPane, checklistsTabButton, checklistsPane);
         }
-        history.replaceState({}, '', currentUrl.toString());
     }
 
-    // Event listener for Defects tab
-    defectsTabButton.addEventListener('click', function () {
-        switchTab(defectsTabButton, defectsPane, checklistsTabButton, checklistsPane);
-        updateURLAnchor('defects');
-    });
+    // Activate tab on initial load
+    activateTabFromHash();
 
-    // Event listener for Checklists tab
-    checklistsTabButton.addEventListener('click', function () {
-        switchTab(checklistsTabButton, checklistsPane, defectsTabButton, defectsPane);
-        updateURLAnchor('checklists');
-    });
-
-    // Initial tab setup based on 'tab' variable from Flask
-    const initialTab = "{{ tab or 'defects' }}"; // Default to 'defects' if tab is not provided
-
-    if (initialTab === 'checklists') {
-        checklistsTabButton.click(); // This will also call updateURLAnchor via the click listener
-    } else {
-        defectsTabButton.click(); // This will also call updateURLAnchor
-    }
+    // Optional: Listen for hash changes if user uses browser back/forward for hash navigation
+    // window.addEventListener('hashchange', activateTabFromHash, false);
+    // For this specific task, direct click updates hash, and initial load reads it.
+    // The above listener would be for full browser history support of hash changes.
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
This commit addresses an issue where the "Back" button on the checklist detail page did not reliably redirect to the "Checklists" tab on the project detail page. The previous attempt used a query parameter, which was incorrect. This fix uses URL fragments (`#checklists`).

The following changes were made:
- The `project_detail` route in `app.py` was reverted to not expect a `_anchor` query parameter for tab control, as fragments are client-side.
- The "Back" button in `templates/checklist_detail.html` was modified to use the URL fragment `#checklists` (e.g., `href=".../project/1#checklists"`).
- JavaScript in `templates/project_detail.html` was updated to:
    - Read `window.location.hash` on page load to determine the active tab.
    - Default to the "Defects" tab if the fragment is missing or not recognized.
    - Update `window.location.hash` when tabs are clicked.

This ensures that when you click the "Back" button on the checklist detail page, you are correctly navigated to the "Checklists" tab on the project detail page using the URL fragment.