### PR TITLE
Fix: Use window.csrfTokenGlobal for checklist item CSRF

### DIFF
--- a/templates/checklist_detail.html
+++ b/templates/checklist_detail.html
@@ -2,7 +2,6 @@
 
 {% block head %}
     {{ super() if super }} {# Include this if layout.html has a head block you want to inherit #}
-    <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{% block title %}Checklist: {{ checklist.name }}{% endblock %}</title> {# Ensure title block is still effective #}
 {% endblock %}
 


### PR DESCRIPTION
The JavaScript for the checklist detail page (`checklist_detail.js`) was failing to send the CSRF token when updating checkbox statuses, leading to 400 errors. This was because it was attempting to read the token from a `<meta name="csrf-token">` tag.

Investigation revealed:
1. The server correctly generates a CSRF token.
2. The `layout.html` template makes this token available via a global JavaScript variable: `window.csrfTokenGlobal`.
3. The `<meta name="csrf-token">` tag was not rendering in `checklist_detail.html` because `layout.html` does not define a `{% block head %}` for the child template to inject into.

This commit addresses the issue by:
1. Removing the unused and non-rendering `<meta name="csrf-token">` from `checklist_detail.html`.
2. Modifying `static/js/checklist_detail.js` to source the CSRF token from `window.csrfTokenGlobal` for all relevant AJAX calls (update status, save comments/attachments, delete attachments).
3. Reverting previous diagnostic changes in `app.py` that explicitly passed the token to the `checklist_detail.html` template context, as this is no longer needed.

The backend test `test_update_status_csrf_protection` remains in place to ensure the endpoint is protected.