### PR TITLE
Fix visual flicker on project detail page load

### DIFF
--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -12,8 +12,8 @@
 
     <!-- Tab Navigation -->
     <div id="tab-navigation" class="flex">
-        <button id="defects-tab-button" class="flex-1 text-center py-3 px-6 text-lg font-bold focus:outline-none transition-all duration-150 ease-in-out rounded-t-lg border-gray-300 border-l border-r border-t">Defects</button>
-        <button id="checklists-tab-button" class="flex-1 text-center py-3 px-6 text-lg font-bold focus:outline-none transition-all duration-150 ease-in-out rounded-t-lg border-gray-300 border-l border-r border-t">Checklists</button>
+        <button id="defects-tab-button" class="flex-1 text-center py-3 px-6 text-lg font-bold focus:outline-none transition-all duration-150 ease-in-out rounded-t-lg border-gray-300 border-l border-r border-t bg-white text-primary relative z-10 mb-[-1px]">Defects</button>
+        <button id="checklists-tab-button" class="flex-1 text-center py-3 px-6 text-lg font-bold focus:outline-none transition-all duration-150 ease-in-out rounded-t-lg border-gray-300 border-l border-r border-t bg-gray-200 text-gray-700 hover:bg-gray-300 border-b">Checklists</button>
     </div>
     <div class="bg-white shadow-lg rounded-b-lg border-l border-r border-b border-gray-300">
         <!-- Actions and Filter Card -->
@@ -25,8 +25,8 @@
                         <a id="add-defect-button" href="{{ url_for('add_defect', project_id=project.id) }}" class="bg-primary hover:bg-primary-hover text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium">Add Defect</a>
                     {% endif %}
                     {% if user_role == 'admin' %}
-                        <a id="add-checklist-button" href="{{ url_for('add_checklist', project_id=project.id) }}" class="bg-primary hover:bg-primary-hover text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium">Add Checklist</a>
-                        <a id="manage-templates-button" href="{{ url_for('template_list') }}" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium text-center">Manage Templates</a>
+                        <a id="add-checklist-button" href="{{ url_for('add_checklist', project_id=project.id) }}" class="bg-primary hover:bg-primary-hover text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium hidden">Add Checklist</a>
+                        <a id="manage-templates-button" href="{{ url_for('template_list') }}" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium text-center hidden">Manage Templates</a>
                     {% endif %}
                     <a id="report-defects-button" href="{{ url_for('generate_new_report', project_id=project.id, filter=filter_status) }}" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium">Report</a>
                 </div>


### PR DESCRIPTION
This commit addresses two visual inconsistencies during the loading of the project detail page:

1.  Resolved an issue where action buttons and filters related to the non-default tab (Checklists) would briefly appear before being hidden by JavaScript. This was fixed by adding the 'hidden' class to these elements directly in the HTML template, ensuring they are not rendered until the Checklists tab is actively selected.

2.  Refined the initial appearance of the default tab button ("Defects"). Previously, it would briefly show in an inactive state (grey) before JavaScript styled it as active (white). This was fixed by applying the active tab styling classes directly to the "Defects" tab button in the HTML and inactive styles to the "Checklists" tab button. The JavaScript tab control logic correctly handles overrides if the page is loaded with a URL hash for a non-default tab.

These changes ensure a smoother and more visually stable loading experience for you on the project detail page.