### PR TITLE
Here's a commit message for the changes you requested:

### DIFF
--- a/app.py
+++ b/app.py
@@ -272,6 +272,19 @@ def ensure_thumbnail_directory():
         os.chmod(thumbnail_dir, 0o755)  # Ensure correct permissions
     return thumbnail_dir
 
+
+@app.context_processor
+def inject_accessible_projects():
+    if current_user.is_authenticated:
+        accessible_project_objects = []
+        # Assuming current_user.projects is a list of ProjectAccess objects
+        project_accesses = ProjectAccess.query.filter_by(user_id=current_user.id).all()
+        project_ids = [access.project_id for access in project_accesses]
+        if project_ids:
+            accessible_project_objects = Project.query.filter(Project.id.in_(project_ids)).order_by(Project.name).all()
+        return dict(accessible_projects=accessible_project_objects)
+    return dict(accessible_projects=[])
+
 # Helper function to ensure specific attachment subdirectories exist
 def ensure_attachment_paths(subfolder_name):
     # Base directory for all uploads, relative to 'static'

--- a/templates/checklist_detail.html
+++ b/templates/checklist_detail.html
@@ -9,9 +9,33 @@
 <div class="container mx-auto py-8 px-4 sm:px-6 lg:px-8">
    <!-- Header: Project Title and Back Button -->
    <div class="flex flex-row justify-between items-center mb-6 pb-4 border-b border-gray-300">
-       <h1 class="text-3xl font-bold text-gray-800">
-           Project: <span class="text-primary">{{ checklist.project.name }}</span>
-       </h1>
+        {% if project and accessible_projects and accessible_projects|length > 0 %}
+        <div class="relative" id="checklist-page-project-dropdown-container">
+            <button type="button" id="checklist-page-project-dropdown-button" class="flex items-center text-2xl font-bold text-gray-800 hover:text-primary focus:outline-none">
+                <span class="text-primary">{{ project.name }}</span> {# project is checklist.project here #}
+                <svg class="ml-2 h-5 w-5 text-gray-600" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+                </svg>
+            </button>
+            <div id="checklist-page-project-dropdown-list" class="absolute left-0 mt-2 w-auto min-w-max max-w-md rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none hidden z-50">
+                <div class="py-1" role="menu" aria-orientation="vertical" aria-labelledby="checklist-page-project-dropdown-button">
+                    <span class="block px-4 py-2 text-sm text-gray-500">Switch project:</span>
+                    {% for acc_proj in accessible_projects %}
+                        {% if acc_proj.id != project.id %}
+                            <a href="{{ url_for('project_detail', project_id=acc_proj.id) }}" class="text-gray-700 block px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900" role="menuitem">{{ acc_proj.name }}</a>
+                        {% endif %}
+                    {% endfor %}
+                    {% if accessible_projects|length == 1 and project.id == accessible_projects[0].id %} {# Only current project accessible #}
+                        <span class="block px-4 py-2 text-sm text-gray-400 italic">No other projects accessible.</span>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        {% else %}
+            <h1 class="text-3xl font-bold text-gray-800">
+                Project: <span class="text-primary">{{ project.name if project else "Unknown" }}</span>
+            </h1>
+        {% endif %}
        <a href="{{ url_for('project_detail', project_id=checklist.project.id) }}#checklists" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back</a>
    </div>
 
@@ -130,4 +154,23 @@
 </div>
 
 <script src="{{ url_for('static', filename='js/checklist_detail.js') }}" defer></script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const checklistPageProjectDropdownButton = document.getElementById('checklist-page-project-dropdown-button');
+    const checklistPageProjectDropdownList = document.getElementById('checklist-page-project-dropdown-list');
+
+    if (checklistPageProjectDropdownButton && checklistPageProjectDropdownList) {
+        checklistPageProjectDropdownButton.addEventListener('click', function (event) {
+            checklistPageProjectDropdownList.classList.toggle('hidden');
+            event.stopPropagation();
+        });
+
+        window.addEventListener('click', function (event) {
+            if (checklistPageProjectDropdownButton && checklistPageProjectDropdownList && !checklistPageProjectDropdownList.classList.contains('hidden') && !checklistPageProjectDropdownButton.contains(event.target) && !checklistPageProjectDropdownList.contains(event.target)) {
+                checklistPageProjectDropdownList.classList.add('hidden');
+            }
+        });
+    }
+});
+</script>
 {% endblock %}

--- a/templates/defect_detail.html
+++ b/templates/defect_detail.html
@@ -4,9 +4,33 @@
 {% block content %}
     <!-- Header: Project Title and Back Button -->
     <div class="flex flex-row justify-between items-center mb-6 pb-4 border-b border-gray-300">
-        <h1 class="text-3xl font-bold text-gray-800">
-            Project: <span class="text-primary">{{ project.name }}</span>
-        </h1>
+        {% if project and accessible_projects and accessible_projects|length > 0 %}
+        <div class="relative" id="defect-page-project-dropdown-container">
+            <button type="button" id="defect-page-project-dropdown-button" class="flex items-center text-2xl font-bold text-gray-800 hover:text-primary focus:outline-none">
+                <span class="text-primary">{{ project.name }}</span> {# project is defect.project here #}
+                <svg class="ml-2 h-5 w-5 text-gray-600" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+                </svg>
+            </button>
+            <div id="defect-page-project-dropdown-list" class="absolute left-0 mt-2 w-auto min-w-max max-w-md rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none hidden z-50">
+                <div class="py-1" role="menu" aria-orientation="vertical" aria-labelledby="defect-page-project-dropdown-button">
+                    <span class="block px-4 py-2 text-sm text-gray-500">Switch project:</span>
+                    {% for acc_proj in accessible_projects %}
+                        {% if acc_proj.id != project.id %}
+                            <a href="{{ url_for('project_detail', project_id=acc_proj.id) }}" class="text-gray-700 block px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900" role="menuitem">{{ acc_proj.name }}</a>
+                        {% endif %}
+                    {% endfor %}
+                    {% if accessible_projects|length == 1 and project.id == accessible_projects[0].id %} {# Only current project accessible #}
+                        <span class="block px-4 py-2 text-sm text-gray-400 italic">No other projects accessible.</span>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        {% else %}
+            <h1 class="text-3xl font-bold text-gray-800">
+                Project: <span class="text-primary">{{ project.name if project else "Unknown" }}</span>
+            </h1>
+        {% endif %}
         <a href="{{ url_for('project_detail', project_id=project.id, filter=defect.status) }}" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back</a>
     </div>
 
@@ -1314,6 +1338,25 @@ document.addEventListener('DOMContentLoaded', function () {
              renderPageEdit(currentPageNumEdit); 
          }
      });
+    });
+    </script>
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const defectPageProjectDropdownButton = document.getElementById('defect-page-project-dropdown-button');
+        const defectPageProjectDropdownList = document.getElementById('defect-page-project-dropdown-list');
+
+        if (defectPageProjectDropdownButton && defectPageProjectDropdownList) {
+            defectPageProjectDropdownButton.addEventListener('click', function (event) {
+                defectPageProjectDropdownList.classList.toggle('hidden');
+                event.stopPropagation();
+            });
+
+            window.addEventListener('click', function (event) {
+                if (defectPageProjectDropdownButton && defectPageProjectDropdownList && !defectPageProjectDropdownList.classList.contains('hidden') && !defectPageProjectDropdownButton.contains(event.target) && !defectPageProjectDropdownList.contains(event.target)) {
+                    defectPageProjectDropdownList.classList.add('hidden');
+                }
+            });
+        }
 });
 </script>
 {% endblock %}

--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -2,10 +2,35 @@
 {% block title %}Project: {{ project.name }}{% endblock %}
 {% block content %}
     <div class="flex flex-row justify-between items-center mb-6 pb-4 border-b border-gray-300">
-        <h1 class="text-3xl font-bold text-gray-800">
-            Project: <span class="text-primary">{{ project.name }}</span>
-        </h1>
-        <a href="{{ url_for('index') }}" class="mt-0 bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium">Back</a>
+        {% if project and accessible_projects and accessible_projects|length > 0 %}
+        <div class="relative" id="page-project-dropdown-container">
+            <button type="button" id="page-project-dropdown-button" class="flex items-center text-2xl font-bold text-gray-800 hover:text-primary focus:outline-none">
+                <span class="text-primary">{{ project.name }}</span>
+                <svg class="ml-2 h-5 w-5 text-gray-600" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+                </svg>
+            </button>
+            <div id="page-project-dropdown-list" class="absolute left-0 mt-2 w-auto min-w-max max-w-md rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none hidden z-50">
+                <div class="py-1" role="menu" aria-orientation="vertical" aria-labelledby="page-project-dropdown-button">
+                    <span class="block px-4 py-2 text-sm text-gray-500">Switch project:</span>
+                    {% for acc_proj in accessible_projects %}
+                        {% if acc_proj.id != project.id %}
+                            <a href="{{ url_for('project_detail', project_id=acc_proj.id) }}" class="text-gray-700 block px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900" role="menuitem">{{ acc_proj.name }}</a>
+                        {% endif %}
+                    {% endfor %}
+                     {% if accessible_projects|length == 1 and project.id == accessible_projects[0].id %} {# Only current project accessible #}
+                        <span class="block px-4 py-2 text-sm text-gray-400 italic">No other projects accessible.</span>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        {% else %}
+            {# Fallback if project context is somehow missing, though it shouldn't be for this page #}
+            <h1 class="text-3xl font-bold text-gray-800">
+                Project: <span class="text-primary">{{ project.name if project else "Unknown" }}</span>
+            </h1>
+        {% endif %}
+        <a href="{{ url_for('index') }}" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium">Back</a>
     </div>
 
 <div class="mx-[-1rem]"> <!-- NEW FULL-WIDTH WRAPPER -->
@@ -426,6 +451,25 @@ document.addEventListener('DOMContentLoaded', function () {
     // window.addEventListener('hashchange', activateTabFromHash, false);
     // For this specific task, direct click updates hash, and initial load reads it.
     // The above listener would be for full browser history support of hash changes.
+});
+</script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const pageProjectDropdownButton = document.getElementById('page-project-dropdown-button');
+    const pageProjectDropdownList = document.getElementById('page-project-dropdown-list');
+
+    if (pageProjectDropdownButton && pageProjectDropdownList) {
+        pageProjectDropdownButton.addEventListener('click', function (event) {
+            pageProjectDropdownList.classList.toggle('hidden');
+            event.stopPropagation();
+        });
+
+        window.addEventListener('click', function (event) {
+            if (pageProjectDropdownButton && pageProjectDropdownList && !pageProjectDropdownList.classList.contains('hidden') && !pageProjectDropdownButton.contains(event.target) && !pageProjectDropdownList.contains(event.target)) {
+                pageProjectDropdownList.classList.add('hidden');
+            }
+        });
+    }
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
```
refactor: Relocate project dropdown to page content

This commit reworks the project navigation dropdown feature based on
your feedback. The dropdown is now implemented directly within the
header section of the `project_detail.html`, `defect_detail.html`,
and `checklist_detail.html` pages, making the project title itself
the dropdown trigger.

The main site navigation bar in `layout.html` has been restored to
its original state, consistently displaying the "Defect Tracker" title.

Key changes:
- Removed project dropdown HTML and JavaScript from `templates/layout.html`.
- Added project dropdown HTML structure (button with project name,
  list of other accessible projects) to the header area of
  `project_detail.html`, `defect_detail.html`, and
  `checklist_detail.html`.
- Added page-specific JavaScript to each of these three templates to
  handle the show/hide interactivity of their respective dropdowns.
- The `inject_accessible_projects` context processor in `app.py`
  remains to provide the list of projects for these dropdowns.
- Confirmed that `app.py` routes correctly pass the `project` object
  (e.g., `defect.project`, `checklist.project`) to these templates.
- Styling is handled via Tailwind CSS within each template.
```