### PR TITLE
Fix: Rename 'Worker' role to 'Contractor' in invite user page

### DIFF
--- a/templates/invite.html
+++ b/templates/invite.html
@@ -33,7 +33,7 @@
                         class="mt-1 block w-full px-3 py-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm">
                     <option value="admin">Admin</option>
                     <option value="expert">Expert</option>
-                    <option value="worker">Worker</option> {# Changed from contractor to worker to match other places #}
+                    <option value="contractor">Contractor</option>
                 </select>
             </div>
 


### PR DESCRIPTION
- I updated the role option in `templates/invite.html` from 'Worker' (value 'worker') to 'Contractor' (value 'contractor').
- This resolves an issue where selecting 'Worker' caused an 'Invalid role selected' error because the backend expects 'contractor'.
- I verified that the backend validation in `app.py` already correctly handles the 'contractor' role.