### PR TITLE
Add delete buttons for defects and checklists

### DIFF
--- a/templates/checklist_detail.html
+++ b/templates/checklist_detail.html
@@ -36,6 +36,16 @@
                 Project: <span class="text-primary">{{ project.name if project else "Unknown" }}</span>
             </h1>
         {% endif %}
+        {% if current_user.role == 'admin' %}
+        <form method="POST" action="{{ url_for('delete_checklist', checklist_id=checklist.id) }}" class="inline">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit"
+                    class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap mr-2"
+                    onclick="return confirm('Are you sure you want to delete this checklist?');">
+                Delete
+            </button>
+        </form>
+        {% endif %}
        <a href="{{ url_for('project_detail', project_id=checklist.project.id) }}#checklists" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back</a>
    </div>
 

--- a/templates/defect_detail.html
+++ b/templates/defect_detail.html
@@ -31,6 +31,16 @@
                 Project: <span class="text-primary">{{ project.name if project else "Unknown" }}</span>
             </h1>
         {% endif %}
+        {% if current_user.role == 'admin' %}
+        <form method="POST" action="{{ url_for('delete_defect', defect_id=defect.id) }}" class="inline">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token_value }}">
+            <button type="submit"
+                    class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap mr-2"
+                    onclick="return confirm('Are you sure you want to delete this defect?');">
+                Delete
+            </button>
+        </form>
+        {% endif %}
         <a href="{{ url_for('project_detail', project_id=project.id, filter=defect.status) }}" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back</a>
     </div>
 


### PR DESCRIPTION
This commit introduces "Delete" buttons on the defect detail and checklist detail pages, allowing administrators to remove these items.

Key changes:
- Added a "Delete" button to `templates/defect_detail.html` next to the "Back" button.
  - Styled in red using Tailwind CSS to indicate a destructive action.
  - Includes a JavaScript confirmation dialog before proceeding.
  - Visible only to users with the 'admin' role.
  - Submits a POST request to `/defect/<defect_id>/delete`.
- Added a similar "Delete" button to `templates/checklist_detail.html`.
  - Visible only to 'admin' role.
  - Submits a POST request to `/checklist/<checklist_id>/delete`.
- Implemented the backend logic in `app.py`:
  - Created a new route `/defect/<int:defect_id>/delete` (POST) that:
    - Verifies admin privileges.
    - Deletes the defect, its associated attachments (including physical files), comments, and markers.
    - Redirects to the project detail page with a success message.
  - Created a new route `/checklist/<int:checklist_id>/delete` (POST) that:
    - Verifies admin privileges.
    - Deletes the checklist, its items, and all associated attachments (including physical files).
    - Redirects to the project detail page with a success message.
  - Corrected the route name for displaying checklist details from `delete_checklist` to `checklist_detail` to avoid conflict.
- Ensured that physical files (originals and thumbnails) associated with deleted defects, checklists, comments, and checklist items are removed from the filesystem.
- Styling for the new buttons is handled by Tailwind CSS; no custom CSS was added.