### PR TITLE
Fix: Correct endpoint names in url_for for delete actions

### DIFF
--- a/templates/checklist_detail.html
+++ b/templates/checklist_detail.html
@@ -37,7 +37,7 @@
             </h1>
         {% endif %}
         {% if current_user.role == 'admin' %}
-        <form method="POST" action="{{ url_for('delete_checklist', checklist_id=checklist.id) }}" class="inline">
+        <form method="POST" action="{{ url_for('delete_checklist_route', checklist_id=checklist.id) }}" class="inline">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit"
                     class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap mr-2"

--- a/templates/defect_detail.html
+++ b/templates/defect_detail.html
@@ -32,7 +32,7 @@
             </h1>
         {% endif %}
         {% if current_user.role == 'admin' %}
-        <form method="POST" action="{{ url_for('delete_defect', defect_id=defect.id) }}" class="inline">
+        <form method="POST" action="{{ url_for('delete_defect_route', defect_id=defect.id) }}" class="inline">
             <input type="hidden" name="csrf_token" value="{{ csrf_token_value }}">
             <button type="submit"
                     class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap mr-2"


### PR DESCRIPTION
Corrected the endpoint names used in `url_for` calls within the `defect_detail.html` and `checklist_detail.html` templates. The previous endpoint names ('delete_defect' and 'delete_checklist') did not match the actual route function names in `app.py`, causing `werkzeug.routing.exceptions.BuildError`.

The `url_for` calls have been updated to use the correct function names:
- `delete_defect_route` for defect deletion.
- `delete_checklist_route` for checklist deletion.

This ensures that the delete buttons on the detail pages now correctly generate URLs and no longer cause a `BuildError`, allowing the pages to load and the delete functionality to be accessed as intended.