### PR TITLE
Style: Reposition delete buttons to the right

### DIFF
--- a/templates/checklist_detail.html
+++ b/templates/checklist_detail.html
@@ -36,17 +36,19 @@
                 Project: <span class="text-primary">{{ project.name if project else "Unknown" }}</span>
             </h1>
         {% endif %}
-        {% if current_user.role == 'admin' %}
-        <form method="POST" action="{{ url_for('delete_checklist_route', checklist_id=checklist.id) }}" class="inline">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit"
-                    class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap mr-2"
-                    onclick="return confirm('Are you sure you want to delete this checklist?');">
-                Delete
-            </button>
-        </form>
-        {% endif %}
-       <a href="{{ url_for('project_detail', project_id=checklist.project.id) }}#checklists" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back</a>
+        <div class="flex items-center">
+            {% if current_user.role == 'admin' %}
+            <form method="POST" action="{{ url_for('delete_checklist_route', checklist_id=checklist.id) }}" class="inline">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit"
+                        class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap mr-2"
+                        onclick="return confirm('Are you sure you want to delete this checklist?');">
+                    Delete
+                </button>
+            </form>
+            {% endif %}
+           <a href="{{ url_for('project_detail', project_id=checklist.project.id) }}#checklists" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back</a>
+        </div>
    </div>
 
     {% if items %}

--- a/templates/defect_detail.html
+++ b/templates/defect_detail.html
@@ -31,17 +31,19 @@
                 Project: <span class="text-primary">{{ project.name if project else "Unknown" }}</span>
             </h1>
         {% endif %}
-        {% if current_user.role == 'admin' %}
-        <form method="POST" action="{{ url_for('delete_defect_route', defect_id=defect.id) }}" class="inline">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token_value }}">
-            <button type="submit"
-                    class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap mr-2"
-                    onclick="return confirm('Are you sure you want to delete this defect?');">
-                Delete
-            </button>
-        </form>
-        {% endif %}
-        <a href="{{ url_for('project_detail', project_id=project.id, filter=defect.status) }}" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back</a>
+        <div class="flex items-center">
+            {% if current_user.role == 'admin' %}
+            <form method="POST" action="{{ url_for('delete_defect_route', defect_id=defect.id) }}" class="inline">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token_value }}">
+                <button type="submit"
+                        class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap mr-2"
+                        onclick="return confirm('Are you sure you want to delete this defect?');">
+                    Delete
+                </button>
+            </form>
+            {% endif %}
+            <a href="{{ url_for('project_detail', project_id=project.id, filter=defect.status) }}" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md shadow-sm text-sm font-medium whitespace-nowrap">Back</a>
+        </div>
     </div>
 
     <!-- New Defect Information Card -->


### PR DESCRIPTION
I've adjusted the layout in `defect_detail.html` and `checklist_detail.html` to move the "Delete" button to the right side of the header, grouped with the "Back" button.

Previously, the "Delete" button was on the left of the "Back" button but both were not explicitly grouped, leading to the "Delete" button appearing in the middle when `justify-between` was applied to the header.

Changes:
- I wrapped the "Delete" button form and the "Back" button anchor tag in a new `div class="flex items-center"` in both templates.
- This new div is now the right-most element in the main header flex container, ensuring the group of buttons aligns to the right.
- The "Delete" button remains to the left of the "Back" button within this group.
- Existing Tailwind CSS classes for styling and spacing were maintained.