### PR TITLE
Fix: Update contractor permissions for comments and defect location

### DIFF
--- a/templates/defect_detail.html
+++ b/templates/defect_detail.html
@@ -212,7 +212,7 @@
                             <canvas id="staticPdfCanvas" class="absolute top-0 left-0"></canvas>
                             <canvas id="staticMarkerCanvas" class="absolute top-0 left-0 pointer-events-none"></canvas>
                         </div>
-                         <p class="text-sm text-gray-700 mt-2">Drawing: {{ marker.drawing_name if marker.drawing_name else (marker.drawing.name if marker.drawing else 'N/A') }} | Page: {{ marker.page_num if marker.page_num else '1' }} | X: {{ "%.3f"|format(marker.x) if marker.x is not none else 'N/A' }} | Y: {{ "%.3f"|format(marker.y) if marker.y is not none else 'N/A' }}</p>
+                         <p class="text-sm text-gray-700 mt-2">Drawing: {{ marker.drawing_name if marker.drawing_name else 'N/A' }} | Page: {{ marker.page_num if marker.page_num else '1' }} | X: {{ "%.3f"|format(marker.x) if marker.x is not none else 'N/A' }} | Y: {{ "%.3f"|format(marker.y) if marker.y is not none else 'N/A' }}</p>
                     {% else %}
                         <p class="text-sm text-gray-500">No drawing location specified for this defect.</p>
                     {% endif %}
@@ -274,7 +274,7 @@
             </div>
 
             <!-- Add Comment Form Card -->
-            {% if user_role in ['admin', 'expert', 'worker'] %}
+            {% if user_role in ['admin', 'expert', 'worker', 'contractor'] %}
                 <div class="bg-white shadow-lg rounded-lg p-6">
                     <h2 class="text-2xl font-semibold text-gray-700 mb-4">Add Comment</h2>
                     <form method="POST" enctype="multipart/form-data" class="space-y-4">
@@ -378,8 +378,9 @@
                     pdfCanvas.style.display = 'block';
 
                     const markerData = {{ marker | tojson }};
-                    // console.log('Marker data:', markerData); // Original log
-                    console.log("Static display - markerData from template:", markerData);
+                    console.log("Static display - User role:", "{{ user_role }}");
+                    console.log("Static display - Marker data from template:", markerData);
+                    if (markerData) { console.log("Static display - Marker file_path:", markerData.file_path); }
                     if (markerData && typeof markerData.x === 'number' && typeof markerData.y === 'number') {
                         ctx.clearRect(0, 0, markerCanvas.width, markerCanvas.height);
                         // Use a more visible marker style


### PR DESCRIPTION
This commit addresses two issues for users with 'contractor' access:

1.  Contractors can now create comments: The "Add Comment" form in `templates/defect_detail.html` was previously hidden from contractors. The condition to display the form has been updated to include the 'contractor' role.

2.  Improved defect location display for contractors:
    - Added JavaScript console logging in `templates/defect_detail.html` to aid in diagnosing issues with the static display of defect location markers and drawings for contractors. This will show the `user_role` and the `markerData` object in the console.
    - Simplified the template logic for displaying the drawing name in the static defect location section, as the backend now consistently provides `marker.drawing_name`.

The backend logic for comment editing permissions already allows users to edit their own comments, which should cover contractors. The defect location data preparation in the backend also appears to be role-agnostic. Further testing in a live environment is recommended to confirm the defect location display for contractors using the added console logs.