### PR TITLE
Fix: Resolve persistent JS SyntaxError and other JS issues

### DIFF
--- a/templates/defect_detail.html
+++ b/templates/defect_detail.html
@@ -378,9 +378,24 @@
                     pdfCanvas.style.display = 'block';
 
                     const markerData = {{ marker | tojson }};
-                    console.log("Static display - User role:", "{{ user_role }}");
-                    console.log("Static display - Marker data from template:", markerData);
-                    if (markerData) { console.log("Static display - Marker file_path:", markerData.file_path); }
+                    /*
+                    var userRoleForJs = {{ user_role | tojson }};
+                    console.log("Static display - User role:", userRoleForJs);
+
+                    try {
+                        console.log("Static display - Marker data from template (JSON):", JSON.stringify(markerData, null, 2));
+                        if (markerData && typeof markerData.file_path !== 'undefined') {
+                            console.log("Static display - Marker file_path:", markerData.file_path);
+                        } else if (markerData) {
+                            console.log("Static display - Marker file_path: (attribute not found or undefined)");
+                        } else {
+                            console.log("Static display - markerData object is null or undefined before checking file_path.");
+                        }
+                    } catch (e) {
+                        console.error("Static display - Error stringifying or logging markerData:", e);
+                        console.log("Static display - Raw markerData object (if stringify failed):", markerData);
+                    }
+                    */
                     if (markerData && typeof markerData.x === 'number' && typeof markerData.y === 'number') {
                         ctx.clearRect(0, 0, markerCanvas.width, markerCanvas.height);
                         // Use a more visible marker style


### PR DESCRIPTION
This commit addresses a persistent JavaScript SyntaxError that was affecting the defect detail page, particularly for contractor users attempting to view marked drawings. It also includes previous fixes for contractor comment permissions and other JavaScript errors.

Key changes:
1.  Resolved `SyntaxError: Unexpected end of input`:
    - A block of detailed JavaScript console logging, added for debugging the static marker display, was found to be the source of a persistent syntax error. This logging block has been removed from `templates/defect_detail.html` to ensure script stability. The error occurred despite attempts to safely embed Jinja variables using `tojson` and `JSON.stringify`.

2.  Resolved `ReferenceError: markerCanvasEdit is not defined`:
    - Removed a redundant/legacy JavaScript block in `templates/defect_detail.html` that referenced outdated or non-existent DOM elements related to an older editable marker interface.

3.  Enabled comment creation for 'contractor' role:
    - Modified `templates/defect_detail.html` to include 'contractor' in the Jinja condition for rendering the "Add Comment" form.

The primary goal of these cumulative changes is to ensure that contractors can create comments and correctly view defect locations (marked drawings) without JavaScript errors hindering page functionality.