### PR TITLE
Fix: Add 'Technical supervisor' to invite page dropdown

### DIFF
--- a/templates/invite.html
+++ b/templates/invite.html
@@ -34,6 +34,7 @@
                     <option value="admin">Admin</option>
                     <option value="expert">Expert</option>
                     <option value="contractor">Contractor</option>
+                    <option value="Technical supervisor">Technical supervisor</option>
                 </select>
             </div>
 

--- a/tests/test_defect_access.py
+++ b/tests/test_defect_access.py
@@ -24,8 +24,11 @@ def test_client():
             admin_user = User(username='test_admin', password=bcrypt.generate_password_hash('password').decode('utf-8'), role='admin')
             expert_user1 = User(username='test_expert1', password=bcrypt.generate_password_hash('password').decode('utf-8'), role='expert')
             expert_user2 = User(username='test_expert2', password=bcrypt.generate_password_hash('password').decode('utf-8'), role='expert')
+            tech_supervisor_user = User(username='tech_supervisor', password=bcrypt.generate_password_hash('password').decode('utf-8'), role='Technical supervisor')
+            another_expert_user = User(username='another_expert', password=bcrypt.generate_password_hash('password').decode('utf-8'), role='expert')
 
-            db.session.add_all([admin_user, expert_user1, expert_user2])
+
+            db.session.add_all([admin_user, expert_user1, expert_user2, tech_supervisor_user, another_expert_user])
             db.session.commit()
 
             # Create a project
@@ -37,14 +40,18 @@ def test_client():
             access_admin = ProjectAccess(user_id=admin_user.id, project_id=project1.id, role='admin')
             access_expert1 = ProjectAccess(user_id=expert_user1.id, project_id=project1.id, role='expert')
             access_expert2 = ProjectAccess(user_id=expert_user2.id, project_id=project1.id, role='expert')
-            db.session.add_all([access_admin, access_expert1, access_expert2])
+            access_tech_supervisor = ProjectAccess(user_id=tech_supervisor_user.id, project_id=project1.id, role='Technical supervisor')
+            access_another_expert = ProjectAccess(user_id=another_expert_user.id, project_id=project1.id, role='expert')
+            db.session.add_all([access_admin, access_expert1, access_expert2, access_tech_supervisor, access_another_expert])
             db.session.commit()
 
             # Create defects
             defect_by_admin = Defect(project_id=project1.id, description='Defect by Admin', creator_id=admin_user.id, creation_date=datetime.now())
             defect_by_expert1 = Defect(project_id=project1.id, description='Defect by Expert 1', creator_id=expert_user1.id, creation_date=datetime.now())
             defect_by_expert2 = Defect(project_id=project1.id, description='Defect by Expert 2', creator_id=expert_user2.id, creation_date=datetime.now())
-            db.session.add_all([defect_by_admin, defect_by_expert1, defect_by_expert2])
+            defect_by_tech_supervisor = Defect(project_id=project1.id, description='Defect by Tech Supervisor', creator_id=tech_supervisor_user.id, creation_date=datetime.now())
+            defect_by_another_expert = Defect(project_id=project1.id, description='Defect by Another Expert', creator_id=another_expert_user.id, creation_date=datetime.now())
+            db.session.add_all([defect_by_admin, defect_by_expert1, defect_by_expert2, defect_by_tech_supervisor, defect_by_another_expert])
             db.session.commit()
 
             yield testing_client # this is where the testing happens!
@@ -247,5 +254,205 @@ def test_admin_report_contains_all_defects(mock_render_template, test_client):
 
     assert defect_by_expert1.id in reported_defect_ids
     assert defect_by_admin.id in reported_defect_ids
+
+    logout(test_client)
+
+
+# --- Tests for Technical Supervisor Role ---
+
+def test_admin_can_invite_technical_supervisor(test_client):
+    admin_user = User.query.filter_by(username='test_admin').first()
+    project1 = Project.query.filter_by(name='Test Project 1').first()
+
+    login(test_client, 'test_admin', 'password')
+
+    # Invite a new user as Technical Supervisor
+    invite_response = test_client.post('/invite', data=dict(
+        project_id=project1.id,
+        role='Technical supervisor'
+    ), follow_redirects=True)
+    assert invite_response.status_code == 200
+    invite_json = invite_response.get_json()
+    assert invite_json['status'] == 'success'
+    assert 'invite_link' in invite_json
+
+    invite_token = invite_json['invite_link'].split('/')[-1]
+
+    # New user accepts invitation
+    logout(test_client) # Log out admin before new user accepts
+
+    accept_response_get = test_client.get(f'/accept_invite/{invite_token}')
+    assert accept_response_get.status_code == 200
+
+    # Simulate form submission for accepting invite
+    # Find the temporary user created by the invite
+    temp_user = User.query.filter(User.username.like('temp_%')).first()
+    assert temp_user is not None
+
+    new_username = 'new_tech_supervisor'
+    new_password = 'new_password'
+
+    accept_response_post = test_client.post(f'/accept_invite/{invite_token}', data=dict(
+        username=new_username,
+        password=new_password,
+        confirm_password=new_password
+    ), follow_redirects=True)
+
+    assert accept_response_post.status_code == 200
+    assert 'Invitation accepted! You are now logged in.' in accept_response_post.get_data(as_text=True)
+
+    # Verify user role and project access
+    newly_registered_user = User.query.filter_by(username=new_username).first()
+    assert newly_registered_user is not None
+    assert newly_registered_user.role == 'Technical supervisor'
+
+    project_access = ProjectAccess.query.filter_by(user_id=newly_registered_user.id, project_id=project1.id).first()
+    assert project_access is not None
+    assert project_access.role == 'Technical supervisor'
+
+    # Clean up: It might be good to delete this user or use transactions if tests interfere
+    logout(test_client)
+
+
+def test_tech_supervisor_sees_all_defects_on_project_page(test_client):
+    project1 = Project.query.filter_by(name='Test Project 1').first()
+    defect_by_admin = Defect.query.filter_by(description='Defect by Admin').first()
+    defect_by_expert1 = Defect.query.filter_by(description='Defect by Expert 1').first()
+    defect_by_tech_supervisor = Defect.query.filter_by(description='Defect by Tech Supervisor').first()
+
+    login(test_client, 'tech_supervisor', 'password')
+    response = test_client.get(f'/project/{project1.id}')
+    assert response.status_code == 200
+    response_data = response.get_data(as_text=True)
+
+    assert defect_by_admin.description in response_data
+    assert defect_by_expert1.description in response_data
+    assert defect_by_tech_supervisor.description in response_data
+    logout(test_client)
+
+def test_tech_supervisor_can_add_defect(test_client):
+    project1 = Project.query.filter_by(name='Test Project 1').first()
+    tech_supervisor_user = User.query.filter_by(username='tech_supervisor').first()
+
+    login(test_client, 'tech_supervisor', 'password')
+
+    defect_description = "New defect by Tech Supervisor"
+    response = test_client.post(f'/project/{project1.id}/add_defect', data=dict(
+        description=defect_description
+        # Assuming no drawing/marker data is mandatory for this test
+    ), follow_redirects=True)
+
+    assert response.status_code == 200 # Should redirect to defect detail page
+    assert 'Defect created successfully!' in response.get_data(as_text=True)
+
+    new_defect = Defect.query.filter_by(description=defect_description, creator_id=tech_supervisor_user.id).first()
+    assert new_defect is not None
+    assert new_defect.project_id == project1.id
+    logout(test_client)
+
+def test_tech_supervisor_can_edit_own_defect(test_client):
+    tech_supervisor_user = User.query.filter_by(username='tech_supervisor').first()
+    defect_by_tech_supervisor = Defect.query.filter_by(creator_id=tech_supervisor_user.id).first()
+
+    login(test_client, 'tech_supervisor', 'password')
+
+    new_description = "Tech Supervisor edited own defect"
+    response = test_client.post(f'/defect/{defect_by_tech_supervisor.id}', data=dict(
+        action='edit_defect',
+        description=new_description,
+        status=defect_by_tech_supervisor.status
+    ), follow_redirects=True)
+
+    assert response.status_code == 200
+    assert 'Defect updated successfully!' in response.get_data(as_text=True)
+    db.session.refresh(defect_by_tech_supervisor)
+    assert defect_by_tech_supervisor.description == new_description
+    logout(test_client)
+
+def test_tech_supervisor_cannot_edit_others_defect(test_client):
+    expert1_user = User.query.filter_by(username='test_expert1').first()
+    defect_by_expert1 = Defect.query.filter_by(creator_id=expert1_user.id).first()
+
+    login(test_client, 'tech_supervisor', 'password')
+
+    original_description = defect_by_expert1.description
+    response = test_client.post(f'/defect/{defect_by_expert1.id}', data=dict(
+        action='edit_defect',
+        description="Attempted edit by Tech Supervisor",
+        status=defect_by_expert1.status
+    ), follow_redirects=True)
+
+    assert response.status_code == 200
+    assert 'You do not have permission to edit this defect.' in response.get_data(as_text=True)
+    db.session.refresh(defect_by_expert1)
+    assert defect_by_expert1.description == original_description # Description should not change
+    logout(test_client)
+
+def test_tech_supervisor_can_close_own_defect(test_client):
+    tech_supervisor_user = User.query.filter_by(username='tech_supervisor').first()
+    # Ensure there's an open defect by the tech supervisor
+    defect_to_close = Defect.query.filter_by(creator_id=tech_supervisor_user.id, status='open').first()
+    if not defect_to_close: # Create one if not exists from fixture
+        project1 = Project.query.filter_by(name='Test Project 1').first()
+        defect_to_close = Defect(project_id=project1.id, description='Open defect for TS to close', creator_id=tech_supervisor_user.id, status='open', creation_date=datetime.now())
+        db.session.add(defect_to_close)
+        db.session.commit()
+
+    login(test_client, 'tech_supervisor', 'password')
+
+    response = test_client.post(f'/defect/{defect_to_close.id}', data=dict(
+        action='edit_defect',
+        description=defect_to_close.description, # Keep description same
+        status='closed'
+    ), follow_redirects=True)
+
+    assert response.status_code == 200
+    assert 'Defect updated successfully!' in response.get_data(as_text=True)
+    db.session.refresh(defect_to_close)
+    assert defect_to_close.status == 'closed'
+    logout(test_client)
+
+def test_tech_supervisor_cannot_close_others_defect(test_client):
+    expert1_user = User.query.filter_by(username='test_expert1').first()
+    # Ensure there's an open defect by expert1
+    defect_by_expert1 = Defect.query.filter_by(creator_id=expert1_user.id, status='open').first()
+    if not defect_by_expert1: # Create one if not exists
+        project1 = Project.query.filter_by(name='Test Project 1').first()
+        defect_by_expert1 = Defect(project_id=project1.id, description='Open defect by Expert 1 for TS test', creator_id=expert1_user.id, status='open', creation_date=datetime.now())
+        db.session.add(defect_by_expert1)
+        db.session.commit()
+
+    login(test_client, 'tech_supervisor', 'password')
+
+    response = test_client.post(f'/defect/{defect_by_expert1.id}', data=dict(
+        action='edit_defect',
+        description=defect_by_expert1.description,
+        status='closed' # Attempt to close
+    ), follow_redirects=True)
+
+    assert response.status_code == 200
+    assert 'You do not have permission to edit this defect.' in response.get_data(as_text=True)
+    db.session.refresh(defect_by_expert1)
+    assert defect_by_expert1.status == 'open' # Status should not change
+    logout(test_client)
+
+
+def test_invite_page_renders_technical_supervisor_option(test_client):
+    # Ensure an admin is logged in to access /invite
+    login(test_client, 'test_admin', 'password')
+
+    response = test_client.get('/invite')
+    assert response.status_code == 200
+    response_data = response.get_data(as_text=True)
+
+    # Check for the option value and text
+    expected_option_html = '<option value="Technical supervisor">Technical supervisor</option>'
+    assert expected_option_html in response_data
+
+    # It's good practice to also check that the other options are still there,
+    # though for this specific subtask, ensuring the new one is present is key.
+    assert '<option value="admin">Admin</option>' in response_data
+    assert '<option value="expert">Expert</option>' in response_data
+    assert '<option value="contractor">Contractor</option>' in response_data
 
     logout(test_client)


### PR DESCRIPTION
This commit corrects an oversight where the 'Technical supervisor' role was not added to the frontend role selection dropdown on the `/invite` page, even though the backend logic supported it.

Changes:
- Modified `templates/invite.html` to include "Technical supervisor" as an option in the role selection.
- Added a new unit test in `tests/test_defect_access.py` to verify that the 'Technical supervisor' option is correctly rendered on the invite page.