### PR TITLE
Fix: Correct checklist filter logic and redirection

### DIFF
--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -69,7 +69,7 @@
                 </div>
                 <div id="filter-checklists-wrapper" class="flex items-center gap-2 mt-3 sm:mt-0 w-full sm:w-auto hidden">
                     <label for="filter_checklists" class="text-sm font-medium text-gray-700 mr-2">Filter:</label>
-                    <select id="filter_checklists" onchange="window.location.href='{{ url_for('project_detail', project_id=project.id) }}?checklist_filter=' + this.value" class="p-2 w-full sm:w-auto md:w-48 border border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary">
+                    <select id="filter_checklists" onchange="window.location.href='{{ url_for('project_detail', project_id=project.id) }}?filter=' + this.value + '#checklists'" class="p-2 w-full sm:w-auto md:w-48 border border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary">
                         <option value="All">All Checklists</option>
                         <option value="Open">Open</option>
                         <option value="Closed">Closed</option>


### PR DESCRIPTION
- I've updated the checklist filter logic in `app.py` to correctly categorize checklists as "Open" (at least one item unchecked) or "Closed" (all items checked or empty).
- I've modified `templates/project_detail.html` to use the `filter` query parameter for checklist filtering and append `#checklists` to the URL, ensuring redirection to the checklists tab.
- I've added unit tests in `tests/test_checklist_features.py` to verify the new filter logic for "Open", "Closed", and "All" states.