### PR TITLE
Fix: Ensure checklist filter dropdown reflects active filter state

### DIFF
--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -70,9 +70,9 @@
                 <div id="filter-checklists-wrapper" class="flex items-center gap-2 mt-3 sm:mt-0 w-full sm:w-auto hidden">
                     <label for="filter_checklists" class="text-sm font-medium text-gray-700 mr-2">Filter:</label>
                     <select id="filter_checklists" onchange="window.location.href='{{ url_for('project_detail', project_id=project.id) }}?filter=' + this.value + '#checklists'" class="p-2 w-full sm:w-auto md:w-48 border border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary">
-                        <option value="All">All Checklists</option>
-                        <option value="Open">Open</option>
-                        <option value="Closed">Closed</option>
+                        <option value="All" {% if filter_status == 'All' %}selected{% endif %}>All Checklists</option>
+                        <option value="Open" {% if filter_status == 'Open' %}selected{% endif %}>Open</option>
+                        <option value="Closed" {% if filter_status == 'Closed' %}selected{% endif %}>Closed</option>
                     </select>
                 </div>
             </div>


### PR DESCRIPTION
- I modified `templates/project_detail.html` to use the `filter_status` template variable to set the `selected` attribute on the checklist filter dropdown options. This ensures the dropdown accurately displays the currently active filter.

This change addresses an issue where the checklist filter dropdown would always default to "All" visually, even if a different filter was active in the backend, leading to your confusion. The backend filtering logic and URL parameters were previously confirmed to be correct.