### PR TITLE
Fix: Prevent tab flickering on project detail page

### DIFF
--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -385,6 +385,28 @@ document.addEventListener('DOMContentLoaded', function () {
 
 <script>
 document.addEventListener('DOMContentLoaded', function () {
+    const projectId = {{ project.id }};
+
+    function getCurrentFilterValue() {
+        const filterDefectsSelect = document.getElementById('filter_defects');
+        const filterChecklistsSelect = document.getElementById('filter_checklists');
+        let currentFilter = 'All'; // Default
+
+        // Try to get from visible select first
+        if (filterDefectsSelect && !filterDefectsSelect.closest('.hidden')) {
+            currentFilter = filterDefectsSelect.value;
+        } else if (filterChecklistsSelect && !filterChecklistsSelect.closest('.hidden')) {
+            currentFilter = filterChecklistsSelect.value;
+        } else {
+            // Fallback to URL search parameter if selects are not available/visible
+            const urlParams = new URLSearchParams(window.location.search);
+            if (urlParams.has('filter')) {
+                currentFilter = urlParams.get('filter');
+            }
+        }
+        return currentFilter;
+    }
+
     const defectsTabButton = document.getElementById('defects-tab-button');
     const checklistsTabButton = document.getElementById('checklists-tab-button');
     const defectsPane = document.getElementById('defects-pane');
@@ -443,16 +465,18 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // Event listener for Defects tab
     defectsTabButton.addEventListener('click', function (event) {
-        // event.preventDefault(); // Not strictly needed for button elements, but good practice if they were <a>
-        switchTab(defectsTabButton, defectsPane, checklistsTabButton, checklistsPane);
-        window.location.hash = 'defects';
+        event.preventDefault();
+        const currentFilter = getCurrentFilterValue();
+        const newUrl = `/project/${projectId}?filter=${currentFilter}&active_tab_override=defects#defects`;
+        window.location.href = newUrl;
     });
 
     // Event listener for Checklists tab
     checklistsTabButton.addEventListener('click', function (event) {
-        // event.preventDefault();
-        switchTab(checklistsTabButton, checklistsPane, defectsTabButton, defectsPane);
-        window.location.hash = 'checklists';
+        event.preventDefault();
+        const currentFilter = getCurrentFilterValue();
+        const newUrl = `/project/${projectId}?filter=${currentFilter}&active_tab_override=checklists#checklists`;
+        window.location.href = newUrl;
     });
 
     // Initial tab setup based on URL hash


### PR DESCRIPTION
The project detail page previously exhibited a flickering behavior where the 'Defects' tab would briefly appear before switching to the 'Checklists' tab under certain conditions (e.g., page refresh, navigating back from checklist detail).

This was caused by the server defaulting to the 'Defects' tab, followed by client-side JavaScript switching to the 'Checklists' tab based on the URL hash.

This commit resolves the issue by modifying the client-side JavaScript for tab clicks in `templates/project_detail.html`. When a tab is now clicked:
1. The URL is updated to include the `active_tab_override` query parameter (set to 'defects' or 'checklists').
2. The current filter status is also included in the URL.
3. The page is reloaded using `window.location.href`.

This ensures that the server always receives the correct intended active tab via the `active_tab_override` parameter and renders the page with the appropriate tab visible from the initial load, eliminating the flicker. The filtering functionality is preserved across tab switches.