### PR TITLE
Fix: Prevent tab flickering on project detail page

### DIFF
--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -48,7 +48,7 @@
         {% set checklists_button_classes = base_button_classes + " " + inactive_button_style %}
     {% endif %}
 
-    <div id="tab-navigation" class="flex">
+    <div id="tab-navigation" class="flex" style="visibility: hidden;">
         <button id="defects-tab-button" class="{{ defects_button_classes }}">Defects</button>
         <button id="checklists-tab-button" class="{{ checklists_button_classes }}">Checklists</button>
     </div>
@@ -500,7 +500,12 @@ document.addEventListener('DOMContentLoaded', function () {
     // Activate tab on initial load
     activateTabFromHash();
 
-    if (tabPanesWrapper) { // New block
+    const tabNavigation = document.getElementById('tab-navigation'); // Added
+    if (tabNavigation) {                                            // Added
+        tabNavigation.style.visibility = 'visible';                // Added
+    }                                                               // Added
+
+    if (tabPanesWrapper) {
         tabPanesWrapper.style.visibility = 'visible';
     }
     // Optional: Listen for hash changes if user uses browser back/forward for hash navigation


### PR DESCRIPTION
The project detail page exhibited a flickering behavior when you loaded it with a URL hash targeting a specific tab (e.g., #checklists). The server would initially render the default tab (Defects) as active, and then client-side JavaScript would switch to the correct tab, causing a visual flicker of the tab buttons.

This commit addresses the issue by:
1. Initially hiding the tab navigation bar (`div#tab-navigation`) using `style="visibility: hidden;"`.
2. Modifying the client-side JavaScript to make the tab navigation bar visible only after it has processed the URL hash and styled the appropriate tab button as active.

This ensures that the tab buttons are only displayed after their correct state has been determined, eliminating the flicker. The functionality for `active_tab_override` in the query parameters remains unaffected and works as intended.