### PR TITLE
Fix: Corrected TypeError in report template iteration.

### DIFF
--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -272,7 +272,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                        {% for item in chk_data.items %}
+                        {% for item in chk_data['items'] %}
                             <tr>
                                 <td>{{ item.item_text }}</td>
                                 <td><span class="status-{{ 'closed' if item.is_checked else 'open' }}">{{ 'Checked' if item.is_checked else 'Unchecked' }}</span></td>


### PR DESCRIPTION
The report generation was failing with a TypeError: 'builtin_function_or_method' object is not iterable. This occurred in `report_template.html` when iterating over checklist items using `chk_data.items`.

The fix changes the iteration from `{% for item in chk_data.items %}` to `{% for item in chk_data['items'] %}`. This ensures explicit dictionary key access for the list of items, preventing any conflict with the `dict.items()` method and resolving the TypeError.