### PR TITLE
fix: Ensure 'Open with no reply' filter is correctly implemented

### DIFF
--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -76,6 +76,7 @@
                     <select id="filter_defects" onchange="window.location.href='{{ url_for('project_detail', project_id=project.id) }}?filter=' + this.value" class="p-2 w-full sm:w-auto md:w-48 border border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary">
                         <option value="All" {% if filter_status == 'All' %}selected{% endif %}>All Defects</option>
                         <option value="Open" {% if filter_status == 'Open' %}selected{% endif %}>Open</option>
+                        <option value="OpenNoReply" {% if filter_status == 'OpenNoReply' %}selected{% endif %}>Open with no reply</option>
                         <option value="OpenWithReply" {% if filter_status == 'OpenWithReply' %}selected{% endif %}>Open with reply</option>
                         <option value="Closed" {% if filter_status == 'Closed' %}selected{% endif %}>Closed</option>
                     </select>


### PR DESCRIPTION
This commit ensures that the 'Open with no reply' filter option is correctly available in the Defects filter dropdown menu on the project detail page and that its backend logic functions as intended.

- Verified and corrected `templates/project_detail.html` to ensure the "Open with no reply" option (value "OpenNoReply") is present in the defects filter dropdown, positioned after "Open", and is not present in the checklists filter.
- Re-verified the backend logic in `app.py` for the 'OpenNoReply' filter status, confirming it correctly queries for open defects with no associated comments.