### PR TITLE
Fix: Ensure PDF.js loads for defects without initial drawings

### DIFF
--- a/templates/defect_detail.html
+++ b/templates/defect_detail.html
@@ -315,10 +315,7 @@
     </div>
 
     {% if marker %}
-    <script src="{{ url_for('static', filename='js/pdf.min.js') }}"></script>
     <script>
-        pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='js/pdf.worker.min.js') }}";
-
         // Script for STATIC PDF/Marker Display (for non-authorized users or when not editing)
         // This script is active if a marker exists and the user is not authorized to edit,
         // or if there's a general need to display a static marker.
@@ -531,6 +528,12 @@
     </script>
     {% endif %}
 
+{% if current_user.id == defect.creator_id or current_user.role in ['admin', 'expert'] %}
+    <script src="{{ url_for('static', filename='js/pdf.min.js') }}"></script>
+    <script>
+        pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='js/pdf.worker.min.js') }}";
+    </script>
+{% endif %}
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     if (typeof pdfjsLib === 'undefined') {


### PR DESCRIPTION
Issue:
When a defect was created without an associated drawing, you were unable to subsequently add a drawing and mark a location in the defect detail view. The drawing selection would occur, but the PDF viewer would not load the selected drawing.

Cause:
The PDF.js library (`pdf.min.js`) and its configuration were only included in the `defect_detail.html` template if an initial marker (`marker` template variable) was present. If no marker existed, `pdfjsLib` would be undefined, and the JavaScript event listeners for the editable drawing functionality (including loading the PDF on selection) would not be set up.

Solution:
I moved the `<script>` tag for `pdf.min.js` and the `pdfjsLib.GlobalWorkerOptions.workerSrc` configuration. These are now included if you have permission to edit the defect location (`current_user.id == defect.creator_id or current_user.role in ['admin', 'expert']`), but critically, they are outside the conditional block `{% if marker %}`.

This ensures that PDF.js is always available for the editable marker section when you have the necessary permissions, allowing drawings to be loaded and marked even if none were associated with the defect initially.