### PR TITLE
Fix: Ensure pdfjsLib is defined before use in static PDF viewer

### DIFF
--- a/templates/defect_detail.html
+++ b/templates/defect_detail.html
@@ -321,7 +321,8 @@
         // or if there's a general need to display a static marker.
         // It targets: staticPdfContainer, staticPdfStatus, staticPdfCanvas, staticMarkerCanvas
         const staticPdfContainer = document.getElementById('staticPdfContainer');
-        if (staticPdfContainer) {
+
+        function initializeStaticPdfViewer() {
             console.log("DEFECT_DETAIL_STATIC_PDF: Script execution started for static PDF preview.");
             try {
                 const pdfStatusEl = document.getElementById('staticPdfStatus');
@@ -417,8 +418,8 @@
 
                 function calculateScaleAndRender(pdfPage) {
                     console.log("DEFECT_DETAIL_STATIC_PDF: calculateScaleAndRender - Starting for page", pdfPage ? pdfPage.pageNumber : 'N/A');
-                    if (!staticPdfContainer) {
-                        console.error("DEFECT_DETAIL_STATIC_PDF: calculateScaleAndRender - staticPdfContainer is null.");
+                    if (!staticPdfContainer) { // This check is inside initializeStaticPdfViewer, but staticPdfContainer is defined outside.
+                        console.error("DEFECT_DETAIL_STATIC_PDF: calculateScaleAndRender - staticPdfContainer is null. This should have been caught earlier.");
                         updateStatus("Error: PDF display container missing.");
                         return;
                     }
@@ -429,10 +430,10 @@
                     }
                     // Calculate scale to fit width, then set height dynamically
                     const pageWidth = pdfPage.getViewport({ scale: 1 }).width;
-                    currentScale = staticPdfContainer.clientWidth / pageWidth; // Changed pdfContainer to staticPdfContainer
+                    currentScale = staticPdfContainer.clientWidth / pageWidth;
 
                     const scaledViewport = pdfPage.getViewport({ scale: currentScale });
-                    staticPdfContainer.style.height = `${scaledViewport.height}px`; // Changed pdfContainer to staticPdfContainer
+                    staticPdfContainer.style.height = `${scaledViewport.height}px`;
 
                     console.log('DEFECT_DETAIL_STATIC_PDF: calculateScaleAndRender - Calculated scale:', currentScale, 'Container clientWidth:', staticPdfContainer.clientWidth);
                     renderPage(pdfPage);
@@ -458,7 +459,6 @@
                     if (rawFilePath.startsWith('/static/')) {
                         rawFilePath = rawFilePath.substring('/static/'.length);
                     }
-                    // This logic for drawings/ prefix might need adjustment based on actual file_path structure
                     if (!rawFilePath.startsWith('drawings/')) {
                         const parts = rawFilePath.split('/');
                         const fileName = parts.pop();
@@ -489,7 +489,7 @@
                         window.addEventListener('resize', () => {
                             clearTimeout(resizeTimeout);
                             resizeTimeout = setTimeout(() => {
-                                if (pdfDoc && pdfDoc.getPage) { // Check if pdfDoc is still valid and has getPage
+                                if (pdfDoc && pdfDoc.getPage) {
                                     pdfDoc.getPage(pageNum).then(calculateScaleAndRender).catch(pageError => {
                                         console.error("DEFECT_DETAIL_STATIC_PDF: Error getting page on resize:", pageError);
                                         updateStatus("Error processing PDF on resize: " + (pageError.message || String(pageError)));
@@ -510,30 +510,46 @@
                         updateStatus('Error loading PDF document: ' + errorMessage);
                     });
                 }
-
                 loadPDF();
-
             } catch (outerError) {
                 console.error("DEFECT_DETAIL_STATIC_PDF: General synchronous error in static PDF script setup:", outerError);
                 // Use updateStatus if available and elements are there, otherwise alert.
-                if (typeof updateStatus === 'function' && document.getElementById('staticPdfStatus')) {
+                // Note: updateStatus is defined inside this try block. If it's not defined yet due to an early error, this might fail.
+                const localPdfStatusEl = document.getElementById('staticPdfStatus'); // Re-fetch for safety in catch
+                if (typeof updateStatus === 'function' && localPdfStatusEl) {
                      updateStatus('Fatal error initializing PDF preview: ' + (outerError.message || String(outerError)));
+                } else if (localPdfStatusEl) { // Basic fallback if updateStatus failed to define
+                    localPdfStatusEl.textContent = 'Fatal error initializing PDF preview: ' + (outerError.message || String(outerError));
+                    localPdfStatusEl.style.color = 'red';
+                    localPdfStatusEl.style.display = 'flex';
                 } else {
                     alert('A critical error occurred setting up the PDF preview. Please refresh the page or contact support if the issue persists.');
                 }
             }
+        }
+
+        function attemptPdfInitialization() {
+            if (typeof pdfjsLib !== 'undefined') {
+                console.log("DEFECT_DETAIL_STATIC_PDF: pdfjsLib is defined, proceeding with initialization.");
+                initializeStaticPdfViewer();
+            } else {
+                console.warn("DEFECT_DETAIL_STATIC_PDF: pdfjsLib is not yet defined. Retrying in 100ms.");
+                setTimeout(attemptPdfInitialization, 100);
+            }
+        }
+
+        if (staticPdfContainer) {
+            attemptPdfInitialization();
         } else {
              console.warn("DEFECT_DETAIL_STATIC_PDF: staticPdfContainer element was not found in the DOM... PDF preview cannot be initialized.");
         }
     </script>
-    {% endif %}
-
-{% if current_user.id == defect.creator_id or current_user.role in ['admin', 'expert'] %}
     <script src="{{ url_for('static', filename='js/pdf.min.js') }}"></script>
     <script>
         pdfjsLib.GlobalWorkerOptions.workerSrc = "{{ url_for('static', filename='js/pdf.worker.min.js') }}";
     </script>
-{% endif %}
+    {% endif %}
+
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     if (typeof pdfjsLib === 'undefined') {


### PR DESCRIPTION
The previous attempt to fix the "pdfjsLib is not defined" error for non-admin users involved moving the script tags. However, the error persisted due to a race condition where the static PDF display script executed before pdf.min.js had fully loaded and defined pdfjsLib.

This commit modifies the static PDF display script in `templates/defect_detail.html` to:
1. Wrap the PDF initialization logic in a function.
2. Implement a checking mechanism (`attemptPdfInitialization`) that waits for `pdfjsLib` to be defined before calling the initialization function. It retries every 100ms if `pdfjsLib` is not yet available.

This ensures that `pdfjsLib` is defined when the static PDF viewer attempts to use it, resolving the race condition and the associated error.