### PR TITLE
Fix: Prevent redundant project access row in your profile

### DIFF
--- a/app.py
+++ b/app.py
@@ -838,11 +838,15 @@ def edit_profile():
     # For GET request
     # The current_user object is already loaded by Flask-Login and is available.
     # current_user.projects should provide ProjectAccess objects.
+    project_accesses = [
+        pa for pa in current_user.projects
+        if pa.project and pa.project.name
+    ]
     return render_template('edit_profile.html',
                            user=current_user,
                            name=current_user.name,
                            company=current_user.company,
-                           project_accesses=current_user.projects)
+                           project_accesses=project_accesses)
 
 # Application Routes
 @app.route('/')


### PR DESCRIPTION
This commit fixes an issue where invited users, after registration, would see a redundant row in the "Your Project Access" section of their edit profile page. This redundant row displayed the correct role but had no project name.

The `edit_profile` route in `app.py` has been modified to filter the `project_accesses` list passed to the template. The filter ensures that only `ProjectAccess` objects with a valid `project` attribute and a non-empty `project.name` are included. This prevents entries with missing or invalid project associations from being rendered, thus removing the redundant row.

The invitation and registration logic was also reviewed and appears to correctly create `ProjectAccess` records with valid project IDs. The issue likely stemmed from older data or edge cases not covered by current creation paths. The implemented filter handles these cases gracefully.