### PR TITLE
Integrate PostgreSQL as the primary database

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pdf2image
 gunicorn
 Flask-Mail==0.9.1
 python-dotenv
+psycopg2-binary


### PR DESCRIPTION
Replaces SQLite with PostgreSQL.

- Adds psycopg2-binary dependency.
- Updates SQLAlchemy database URI configuration in app.py to support PostgreSQL, defaulting to a local placeholder URI.
- Removes SQLite-specific instance directory creation and checks.
- Modifies Flask CLI commands (ensure-schema, ensure-user-schema) to use SQLAlchemy's inspector and more database-agnostic DDL, removing SQLite PRAGMA statements.

Manual testing against a configured PostgreSQL instance is required. Automated tests continue to use SQLite.