### PR TITLE
Add database indexes to frequently queried columns

### DIFF
--- a/app.py
+++ b/app.py
@@ -139,11 +139,15 @@ class ProjectAccess(db.Model):
     role = db.Column(db.String(50), nullable=False)
     user = db.relationship('User', back_populates='projects')
     project = db.relationship('Project')
+    __table_args__ = (
+        db.Index('ix_project_access_user_id', 'user_id'),
+        db.Index('ix_project_access_project_id', 'project_id'),
+    )
 
 class Project(db.Model):
     __tablename__ = 'projects'
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(255))
+    name = db.Column(db.String(255), index=True) # Added index for project name
     defects = db.relationship('Defect', back_populates='project', cascade='all, delete-orphan')
     checklists = db.relationship('Checklist', back_populates='project', cascade='all, delete-orphan')
     accesses = db.relationship('ProjectAccess', back_populates='project', cascade='all, delete-orphan')
@@ -163,6 +167,12 @@ class Defect(db.Model):
     comments = db.relationship('Comment', back_populates='defect', cascade='all, delete-orphan')
     creator = db.relationship('User')
     markers = db.relationship('DefectMarker', back_populates='defect', cascade='all, delete-orphan')
+    __table_args__ = (
+        db.Index('ix_defect_project_id', 'project_id'),
+        db.Index('ix_defect_status', 'status'),
+        db.Index('ix_defect_creator_id', 'creator_id'),
+        db.Index('ix_defect_creation_date', 'creation_date'),
+    )
 
 class Drawing(db.Model):
     __tablename__ = 'drawings'
@@ -173,6 +183,9 @@ class Drawing(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.now)
     project = db.relationship('Project', back_populates='drawings')
     markers = db.relationship('DefectMarker', back_populates='drawing', cascade='all, delete-orphan')
+    __table_args__ = (
+        db.Index('ix_drawing_project_id', 'project_id'),
+    )
 
 class DefectMarker(db.Model):
     __tablename__ = 'defect_markers'
@@ -185,6 +198,10 @@ class DefectMarker(db.Model):
     page_num = db.Column(db.Integer, nullable=False, default=1) 
     defect = db.relationship('Defect', back_populates='markers')
     drawing = db.relationship('Drawing', back_populates='markers')
+    __table_args__ = (
+        db.Index('ix_defect_marker_defect_id', 'defect_id'),
+        db.Index('ix_defect_marker_drawing_id', 'drawing_id'),
+    )
 
     def to_dict(self):
         return {
@@ -210,6 +227,11 @@ class Comment(db.Model):
     defect = db.relationship('Defect', back_populates='comments')
     user = db.relationship('User')
     attachments = db.relationship('Attachment', back_populates='comment', cascade='all, delete-orphan')
+    __table_args__ = (
+        db.Index('ix_comment_defect_id', 'defect_id'),
+        db.Index('ix_comment_user_id', 'user_id'),
+        db.Index('ix_comment_created_at', 'created_at'),
+    )
 
 class Attachment(db.Model):
     __tablename__ = 'attachments'
@@ -223,11 +245,16 @@ class Attachment(db.Model):
     defect = db.relationship('Defect', back_populates='attachments')
     checklist_item = db.relationship('ChecklistItem', back_populates='attachments')
     comment = db.relationship('Comment', back_populates='attachments')
+    __table_args__ = (
+        db.Index('ix_attachment_defect_id', 'defect_id'),
+        db.Index('ix_attachment_checklist_item_id', 'checklist_item_id'),
+        db.Index('ix_attachment_comment_id', 'comment_id'),
+    )
 
 class Template(db.Model):
     __tablename__ = 'templates'
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(255))
+    name = db.Column(db.String(255), index=True) # Added index for template name
     items = db.relationship('TemplateItem', back_populates='template', cascade='all, delete-orphan')
 
 class TemplateItem(db.Model):
@@ -236,6 +263,9 @@ class TemplateItem(db.Model):
     template_id = db.Column(db.Integer, db.ForeignKey('templates.id'))
     item_text = db.Column(db.String(255))
     template = db.relationship('Template', back_populates='items')
+    __table_args__ = (
+        db.Index('ix_template_item_template_id', 'template_id'),
+    )
 
 class Checklist(db.Model):
     __tablename__ = 'checklists'
@@ -246,6 +276,10 @@ class Checklist(db.Model):
     creation_date = db.Column(db.DateTime, default=datetime.now)
     project = db.relationship('Project', back_populates='checklists')
     items = db.relationship('ChecklistItem', back_populates='checklist', cascade='all, delete-orphan')
+    __table_args__ = (
+        db.Index('ix_checklist_project_id', 'project_id'),
+        db.Index('ix_checklist_template_id', 'template_id'),
+    )
 
 class ChecklistItem(db.Model):
     __tablename__ = 'checklist_items'
@@ -256,6 +290,10 @@ class ChecklistItem(db.Model):
     comments = db.Column(db.String(255), default='')
     checklist = db.relationship('Checklist', back_populates='items')
     attachments = db.relationship('Attachment', back_populates='checklist_item', cascade='all, delete-orphan')
+    __table_args__ = (
+        db.Index('ix_checklist_item_checklist_id', 'checklist_id'),
+        db.Index('ix_checklist_item_is_checked', 'is_checked'),
+    )
 
 # Database initialization
 db_init_lock = Lock()


### PR DESCRIPTION
Added db.Index definitions to SQLAlchemy models for foreign keys and frequently filtered columns across various tables including ProjectAccess, Defect, Drawing, DefectMarker, Comment, Attachment, TemplateItem, Checklist, and ChecklistItem.

Also added index=True for Project.name and Template.name.

These changes aim to improve database query performance.