### PR TITLE
Add product approval counts to project list page

### DIFF
--- a/app.py
+++ b/app.py
@@ -2000,11 +2000,23 @@ def index():
             Checklist.items.any(ChecklistItem.is_checked == False)
         ).count()
 
+        products_waiting_for_proposal_count = ProductApproval.query.filter_by(
+            project_id=project.id,
+            status='waiting_for_proposal'
+        ).count()
+
+        products_provided_waiting_for_approval_count = ProductApproval.query.filter_by(
+            project_id=project.id,
+            status='product_provided'
+        ).count()
+
         projects_data.append({
             'project': project,
             'open_defects_count': open_defects_count,
             'open_defects_with_reply_count': open_defects_with_reply_count,
             'open_checklists_count': open_checklists_count,
+            'products_waiting_for_proposal_count': products_waiting_for_proposal_count,
+            'products_provided_waiting_for_approval_count': products_provided_waiting_for_approval_count,
         })
 
     return render_template('project_list.html', projects_data=projects_data)

--- a/templates/project_list.html
+++ b/templates/project_list.html
@@ -29,6 +29,8 @@
                             <li>Open Defects: <span class="font-semibold">{{ data_item.open_defects_count }}</span></li>
                             <li>Open Defects with Replies: <span class="font-semibold">{{ data_item.open_defects_with_reply_count }}</span></li>
                             <li>Open Checklists: <span class="font-semibold">{{ data_item.open_checklists_count }}</span></li>
+                            <li>Products waiting for proposal: <span class="font-semibold">{{ data_item.products_waiting_for_proposal_count }}</span></li>
+                            <li>Products provided waiting for approval: <span class="font-semibold">{{ data_item.products_provided_waiting_for_approval_count }}</span></li>
                         </ul>
                     </div>
 


### PR DESCRIPTION
This change modifies the project list page to display counts for:
- Products waiting for proposal
- Products provided waiting for approval

This involved:
- Updating the `index()` route in `app.py` to query and calculate these counts.
- Modifying `templates/project_list.html` to render the new statistics.