### PR TITLE
Fix: Product approval filter dropdown UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -2223,6 +2223,14 @@ def project_detail(project_id):
     # product_approval_filter_status = request.args.get('product_approval_filter', 'All')
     # if product_approval_filter_status != 'All':
     #    product_approvals_query = product_approvals_query.filter(ProductApproval.status == product_approval_filter_status)
+    product_filter_status = request.args.get('product_filter_status', 'All')
+    if product_filter_status == 'waiting_for_proposal':
+        product_approvals_query = product_approvals_query.filter(ProductApproval.status == 'waiting_for_proposal')
+    elif product_filter_status == 'product_provided':
+        product_approvals_query = product_approvals_query.filter(ProductApproval.status == 'product_provided')
+    elif product_filter_status == 'rejected':
+        product_approvals_query = product_approvals_query.filter(ProductApproval.status == 'rejected')
+    # Else, no specific product approval filter is applied, showing all for the project.
 
     product_approvals_for_template = product_approvals_query.options(
         joinedload(ProductApproval.documents).joinedload(ProductDocument.uploader),
@@ -2231,7 +2239,7 @@ def project_detail(project_id):
         joinedload(ProductApproval.approver)
     ).all()
 
-    return render_template('project_detail.html', project=project, defects=defects, checklists=filtered_checklists, filter_status=filter_status, user_role=access.role, active_tab_name=active_tab_override, product_approvals=product_approvals_for_template) # Added product_approvals
+    return render_template('project_detail.html', project=project, defects=defects, checklists=filtered_checklists, filter_status=filter_status, user_role=access.role, active_tab_name=active_tab_override, product_approvals=product_approvals_for_template, product_filter_status=product_filter_status) # Added product_approvals and product_filter_status
 
 @app.route('/project/<int:project_id>/add_drawing', methods=['GET', 'POST'])
 @login_required

--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -95,12 +95,12 @@
                 </div>
                 <div id="filter-products-approval-wrapper" class="flex items-center gap-2 mt-3 sm:mt-0 w-full sm:w-auto hidden">
                     <label for="filter_products_approval" class="text-sm font-medium text-gray-700 mr-2">Filter:</label>
-                    <select id="filter_products_approval" onchange="window.location.href='{{ url_for('project_detail', project_id=project.id) }}?filter=' + this.value + '&active_tab_override=products_approval#products_approval'" class="p-2 w-full sm:w-auto md:w-48 border border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary">
-                        <option value="All" {% if filter_status == 'All' %}selected{% endif %}>All Requests</option>
-                        <option value="waiting_for_proposal" {% if filter_status == 'waiting_for_proposal' %}selected{% endif %}>Waiting for Proposal</option>
-                        <option value="product_provided" {% if filter_status == 'product_provided' %}selected{% endif %}>Product Provided</option>
-                        <option value="approved" {% if filter_status == 'approved' %}selected{% endif %}>Approved</option>
-                        <option value="rejected" {% if filter_status == 'rejected' %}selected{% endif %}>Rejected</option>
+                    <select id="filter_products_approval" onchange="window.location.href='{{ url_for('project_detail', project_id=project.id) }}?product_filter_status=' + this.value + '&active_tab_override=products_approval#products_approval'" class="p-2 w-full sm:w-auto md:w-48 border border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary">
+                        <option value="All" {% if product_filter_status == 'All' or not product_filter_status %}selected{% endif %}>All Requests</option>
+                        <option value="waiting_for_proposal" {% if product_filter_status == 'waiting_for_proposal' %}selected{% endif %}>Waiting for Proposal</option>
+                        <option value="product_provided" {% if product_filter_status == 'product_provided' %}selected{% endif %}>Product Provided</option>
+                        <option value="approved" {% if product_filter_status == 'approved' %}selected{% endif %}>Approved</option>
+                        <option value="rejected" {% if product_filter_status == 'rejected' %}selected{% endif %}>Rejected</option>
                     </select>
                 </div>
             </div>

--- a/templates/project_list.html
+++ b/templates/project_list.html
@@ -26,12 +26,12 @@
                     <div class="mt-4 border-t border-gray-200 pt-4">
                         <h4 class="text-sm font-medium text-gray-700 mb-2">Statistics:</h4>
                         <ul class="text-sm text-gray-600 space-y-1">
-                            <li>Open Defects: <span class="font-semibold">{{ data_item.open_defects_count }}</span></li>
-                            <li>Open Defects with Replies: <span class="font-semibold">{{ data_item.open_defects_with_reply_count }}</span></li>
-                            <li>Open Checklists: <span class="font-semibold">{{ data_item.open_checklists_count }}</span></li>
-                            <li>Products waiting for proposal: <span class="font-semibold">{{ data_item.products_waiting_for_proposal_count }}</span></li>
-                            <li>Products provided waiting for approval: <span class="font-semibold">{{ data_item.products_provided_waiting_for_approval_count }}</span></li>
-                            <li>Products rejected: <span class="font-semibold">{{ data_item.products_rejected_count }}</span></li>
+                            <li>Open Defects: <a href="{{ url_for('project_detail', project_id=data_item.project.id, filter='Open', active_tab_override='defects') }}" class="text-sky-600 hover:underline"><span class="font-semibold">{{ data_item.open_defects_count }}</span></a></li>
+                            <li>Open Defects with Replies: <a href="{{ url_for('project_detail', project_id=data_item.project.id, filter='OpenWithReply', active_tab_override='defects') }}" class="text-sky-600 hover:underline"><span class="font-semibold">{{ data_item.open_defects_with_reply_count }}</span></a></li>
+                            <li>Open Checklists: <a href="{{ url_for('project_detail', project_id=data_item.project.id, filter='Open', active_tab_override='checklists') }}" class="text-sky-600 hover:underline"><span class="font-semibold">{{ data_item.open_checklists_count }}</span></a></li>
+                            <li>Products waiting for proposal: <a href="{{ url_for('project_detail', project_id=data_item.project.id, active_tab_override='products_approval', product_filter_status='waiting_for_proposal') }}" class="text-sky-600 hover:underline"><span class="font-semibold">{{ data_item.products_waiting_for_proposal_count }}</span></a></li>
+                            <li>Products provided waiting for approval: <a href="{{ url_for('project_detail', project_id=data_item.project.id, active_tab_override='products_approval', product_filter_status='product_provided') }}" class="text-sky-600 hover:underline"><span class="font-semibold">{{ data_item.products_provided_waiting_for_approval_count }}</span></a></li>
+                            <li>Products rejected: <a href="{{ url_for('project_detail', project_id=data_item.project.id, active_tab_override='products_approval', product_filter_status='rejected') }}" class="text-sky-600 hover:underline"><span class="font-semibold">{{ data_item.products_rejected_count }}</span></a></li>
                         </ul>
                     </div>
 


### PR DESCRIPTION
The filter dropdown on the product approvals tab in project_detail.html now correctly reflects the active `product_filter_status` passed via the URL.

- Modified `onchange` URL generation in the dropdown to use `product_filter_status`.
- Updated option selection logic to use `product_filter_status` variable.